### PR TITLE
Update modules.lst

### DIFF
--- a/modules.lst
+++ b/modules.lst
@@ -180,6 +180,3 @@ module m_quietban 2.0.0 https://raw.github.com/inspircd/inspircd-extras/eff96188
  conflicts m_muteban.so
  conflicts m_chanprotect.so
  description Provides channel mode +q for 'quiet' bans.
-module m_invisible 2.1.134 https://raw.github.com/inspircd/inspircd-extras/93f027e93157860173200d1b7d6ea9a708889ef7/2.1/m_invisible.cpp
- depends core 2.1
- description Allows for opered clients to join channels without being seen, similar to unreal 3.1 +I mode


### PR DESCRIPTION
Removed reference to m_invisible as InspIRCd is deprecated and there is a duplicate module in 2.0 and and the appropriate call to it already in this file.
