### PR TITLE
m_dccblock module to completely block DCC transfers for the safety of users

### DIFF
--- a/2.0/m_dccblock.cpp
+++ b/2.0/m_dccblock.cpp
@@ -68,7 +68,7 @@ class ModuleDCCBlock : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for blocking DCC transfers", VF_COMMON | VF_VENDOR);
+		return Version("Provides support for blocking DCC transfers");
 	}
 };
 


### PR DESCRIPTION
Hi,

I naively tried to submit a previous revision of this patch to the inspircd 2.0 repository a few days ago, not realizing it was feature locked.  Also, when I submitted it before, an alternative configuration option was suggested to do something similar to this module, but this module is superior for the reasons I'll describe here and it would be nice if it was available for others to use in the inspircd-extras collection.

On some IRC networks with anonymity/privacy are of paramount concern, the hiding of user IP addresses is critical even from operators of the network.  Commands like DCC can be very dangerous because with poorly configured clients, they may expose their real IP address.

This module is derived from m_dccallow, and has basically all the cruft for handling exception lists removed.  What it does is intercept DCC and DCCALLOW commands, and give a response to the user indicative of server policy, such as that "DCC is not allowed on this server.  No exceptions".

This plugin requires no configuration options and it is a piece of cake to load in place of m_dccallow.so if you are sure you want nothing DCC related on your IRC server.

Without the module, the accepted practice to disable all DCC transfers is to configure the m_dccallow module appropriately, and to insert an extra clause in the inspircd.conf to disable the DCCALLOW command for non-IRC operators.  But of course, in some networks, you want the commands disabled for all users, even some that may be designated as operators.  Also, when blocked in the old way with DCC allow, the error messages still indicate that DCC may be allowed on the server and that the user is not accepting messages.  For servers where DCC is meant to be off limits unilateral, I this module's approach is safer where it requires no tricky configuration, applies to all users including operators, and gives a more relevant error to the user who tries to DCC in line with your server policy.

As an aside, if you like this module, I do also have a new version that works in the 2.2 development branch.  Is that something you want also, and since 2.2 is in active development would it  be better to submit to the main 2.2 branch instead of inspircd-extras?

Thanks for your consideration,
Jansteen
