### PR TITLE
Port two specialized autojoin modules.

### DIFF
--- a/3.0/m_conn_join_geoip.cpp
+++ b/3.0/m_conn_join_geoip.cpp
@@ -1,0 +1,77 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2014 Attila Molnar <attilamolnar@hush.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <autojoingeoip country="CA" chan="#canada">
+/// $ModDepends: core 3
+/// $ModDesc: Autojoin users to a channel based on GeoIP.
+
+
+#include "inspircd.h"
+#include "modules/geolocation.h"
+
+class ModuleConnJoinGeoIP : public Module
+{
+	Geolocation::API geoapi;
+	typedef std::multimap<std::string, std::string> CountryChans;
+	CountryChans chans;
+
+ public:
+	ModuleConnJoinGeoIP()
+		: geoapi(this)
+	{
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		chans.clear();
+
+		ConfigTagList tags = ServerInstance->Config->ConfTags("autojoingeoip");
+		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		{
+			ConfigTag* tag = i->second;
+			chans.insert(std::make_pair(tag->getString("country"), tag->getString("chan")));
+		}
+	}
+
+	void OnPostConnect(User* user) CXX11_OVERRIDE
+	{
+		LocalUser* localuser = IS_LOCAL(user);
+		if (!localuser)
+			return;
+
+		Geolocation::Location* location = geoapi ? geoapi->GetLocation(localuser) : NULL;
+		const std::string code = location ? location->GetCode() : "XX";
+
+		std::pair<CountryChans::const_iterator, CountryChans::const_iterator> itp = chans.equal_range(code);
+		for (CountryChans::const_iterator i = itp.first; i != itp.second; ++i)
+		{
+			const std::string& channame = i->second;
+			if (ServerInstance->IsChannel(channame))
+				Channel::JoinUser(localuser, channame);
+		}
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Autojoins users based on GeoIP");
+	}
+};
+
+MODULE_INIT(ModuleConnJoinGeoIP)

--- a/3.0/m_conn_join_ident.cpp
+++ b/3.0/m_conn_join_ident.cpp
@@ -1,0 +1,69 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2014 Attila Molnar <attilamolnar@hush.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <autojoinident ident="bad*" chan="#bads">
+/// $ModDepends: core 3
+/// $ModDesc: Autojoin users to a channel based on their ident.
+
+
+#include "inspircd.h"
+
+class ModuleConnJoinIdent : public Module
+{
+	typedef std::vector<std::pair<std::string, std::string> > IdentChanList;
+	IdentChanList chans;
+
+ public:
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		chans.clear();
+
+		ConfigTagList tags = ServerInstance->Config->ConfTags("autojoinident");
+		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		{
+			ConfigTag* tag = i->second;
+			chans.push_back(std::make_pair(tag->getString("ident"), tag->getString("chan")));
+		}
+	}
+
+	void OnPostConnect(User* user) CXX11_OVERRIDE
+	{
+		LocalUser* localuser = IS_LOCAL(user);
+		if (!localuser)
+			return;
+
+		for (IdentChanList::const_iterator i = chans.begin(); i != chans.end(); ++i)
+		{
+			if (!InspIRCd::Match(localuser->ident, i->first))
+				continue;
+
+			const std::string& channame = i->second;
+			if (ServerInstance->IsChannel(channame))
+				Channel::JoinUser(localuser, channame);
+		}
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Autojoins users based on their ident");
+	}
+};
+
+MODULE_INIT(ModuleConnJoinIdent)


### PR DESCRIPTION
Port two specialized autojoin modules that @attilamolnar previously wrote for a user for 2.0.
Both are tested to function as expected.

Resolves #219.