### PR TITLE
m_extbanregex: Update the used channel notice method.

### DIFF
--- a/3.0/m_extbanregex.cpp
+++ b/3.0/m_extbanregex.cpp
@@ -100,9 +100,13 @@ void RemoveAll(const std::string& engine, ChanModeReference& ban, ChanModeRefere
 		PrefixMode* hop = ServerInstance->Modes->FindPrefixMode('h');
 		char pfxchar = (hop && hop->name == "halfop") ? hop->GetPrefix() : '@';
 
+#if defined INSPIRCD_VERSION_BEFORE && INSPIRCD_VERSION_BEFORE(3, 5)
 		ClientProtocol::Messages::Privmsg notice(ServerInstance->FakeClient, chan, msg, MSG_NOTICE);
 		chan->Write(ServerInstance->GetRFCEvents().privmsg, notice, pfxchar);
-		ServerInstance->PI->SendChannelNotice(chan, pfxchar, msg);
+		ServerInstance->PI->SendMessage(chan, pfxchar, msg, MSG_NOTICE);
+#else
+		chan->WriteNotice(msg, pfxchar);
+#endif
 	}
 }
 } // namespace


### PR DESCRIPTION
## Summary
Update the channel notice method used for two possibilities:
1) `SendChannelNotice` is now deprecated and it's replacement has been available since 3.0.0(a1)
2) Use the updated `WriteNotice` if the version is new enough. This method was recently changed in the insp3 branch, not in a release as of yet. I'm guessing that the next release will be 3.5.0.

## Rationale
Just keeping updated with the core. As for the version check, people tend to not upgrade as often as they should.

## Testing Environment
I have tested this pull request on:

Operating system name and version: Ubuntu 16.04
Compiler name and version: GCC 5.4.0
