### PR TITLE
Implement CI.

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,70 @@
+name: Linux CI
+on:
+  push:
+    paths:
+      - '3.0/*'
+  pull_request:
+    paths:
+      - '3.0/*'
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    env:
+      CXXFLAGS: -std=${{ matrix.standard }} -Wno-error=deprecated-declarations
+      CXX: ${{ matrix.compiler }}
+      INSPIRCD_DEBUG: 3
+      INSPIRCD_VERBOSE: 1
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update --assume-yes
+          sudo apt-get install --assume-yes --no-install-recommends clang g++ git make libc++-dev libc++abi-dev pkg-config
+      - name: Checkout InspIRCd@insp3
+        uses: actions/checkout@v2
+        with:
+          repository: 'inspircd/inspircd'
+          ref: 'insp3'
+          path: 'inspircd'
+      - name: Checkout self
+        uses: actions/checkout@v2
+        with:
+          path: 'contrib'
+      - name: (Pull Request) Set the build target to only the changed modules
+        if: github.event_name == 'pull_request'
+        run: |
+          cd contrib
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          echo ::set-env name=INSPIRCD_TARGET::$( \
+          git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} | \
+          for f in `cat`; do if [[ "$f" = "3.0/"*".cpp" ]]; \
+          then echo "$(basename $f .cpp) "; fi; done)
+      - name: (Push/PR Fallback) Set the build target to all of the modules
+        if: github.event_name == 'push' || env.INSPIRCD_TARGET == ''
+        run: echo ::set-env name=INSPIRCD_TARGET::$(for f in contrib/3.0/*; do echo "$(basename $f .cpp) "; done)
+      - name: Symlink the modules
+        run: |
+          cd inspircd/src/modules
+          ln -s ../../../contrib/3.0/* .
+      - name: Check for additional dependencies
+        run: |
+          cd inspircd
+          echo ::set-env name=PACKAGES::$( \
+          for f in ../contrib/3.0/*; do if [[ "$INSPIRCD_TARGET" = *"$(basename $f .cpp)"* ]]; \
+          then ./tools/directive $f PackageInfo; fi; done)
+      - name: Install additional dependencies
+        if: env.PACKAGES != ''
+        run: sudo apt-get install --assume-yes --no-install-recommends ${{ env.PACKAGES }}
+      - name: Build the modules
+        run: |
+          cd inspircd
+          ./configure --development --disable-auto-extras
+          make --jobs $(($(getconf _NPROCESSORS_ONLN) + 1))
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - clang++
+          - g++
+        standard:
+          - gnu++98
+          - c++14

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,67 @@
+name: macOS CI
+on:
+  push:
+    paths:
+      - '3.0/*'
+  pull_request:
+    paths:
+      - '3.0/*'
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      CXXFLAGS: -std=${{ matrix.standard }} -Wno-error=deprecated-declarations
+      INSPIRCD_DEBUG: 3
+      INSPIRCD_VERBOSE: 1
+    steps:
+      - name: Install dependencies
+        run: |
+          brew update
+          brew upgrade
+          brew install pkg-config
+      - name: Checkout InspIRCd@insp3
+        uses: actions/checkout@v2
+        with:
+          repository: 'inspircd/inspircd'
+          ref: 'insp3'
+          path: 'inspircd'
+      - name: Checkout self
+        uses: actions/checkout@v2
+        with:
+          path: 'contrib'
+      - name: (Pull Request) Set the build target to only the changed modules
+        if: github.event_name == 'pull_request'
+        run: |
+          cd contrib
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          echo ::set-env name=INSPIRCD_TARGET::$( \
+          git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} | \
+          for f in `cat`; do if [[ "$f" = "3.0/"*".cpp" ]]; \
+          then echo "$(basename $f .cpp) "; fi; done)
+      - name: (Push/PR Fallback) Set the build target to all of the modules
+        if: github.event_name == 'push' || env.INSPIRCD_TARGET == ''
+        run: echo ::set-env name=INSPIRCD_TARGET::$(for f in contrib/3.0/*; do echo "$(basename $f .cpp) "; done)
+      - name: Symlink the modules
+        run: |
+          cd inspircd/src/modules
+          ln -s ../../../contrib/3.0/* .
+      - name: Check for additional dependencies
+        run: |
+          cd inspircd
+          echo ::set-env name=PACKAGES::$( \
+          for f in ../contrib/3.0/*; do if [[ "$INSPIRCD_TARGET" = *"$(basename $f .cpp)"* ]]; \
+          then ./tools/directive $f PackageInfo; fi; done)
+      - name: Install additional dependencies
+        if: env.PACKAGES != ''
+        run: brew install ${{ env.PACKAGES }}
+      - name: Build the modules
+        run: |
+          cd inspircd
+          ./configure --development --disable-auto-extras
+          make --jobs $(($(sysctl -n hw.activecpu) + 1))
+    strategy:
+      fail-fast: false
+      matrix:
+        standard:
+          - gnu++98
+          - c++14

--- a/3.0/m_qrcode.cpp
+++ b/3.0/m_qrcode.cpp
@@ -19,6 +19,12 @@
 /// $CompilerFlags: find_compiler_flags("libqrencode")
 /// $LinkerFlags: find_linker_flags("libqrencode")
 
+/// $PackageInfo: require_system("arch") qrencode pkgconf
+/// $PackageInfo: require_system("centos") qrencode-devel pkgconfig
+/// $PackageInfo: require_system("darwin") qrencode pkg-config
+/// $PackageInfo: require_system("debian") libqrencode3 libqrencode-dev pkg-config
+/// $PackageInfo: require_system("ubuntu") libqrencode3 libqrencode-dev pkg-config
+
 /// $ModAuthor: Sadie Powell
 /// $ModAuthorMail: sadie@witchery.services
 /// $ModDesc: Provides support for QR code generation via the /QRCODE command.
@@ -29,7 +35,26 @@
 #include "inspircd.h"
 #include "modules/ssl.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
+// Fix warnings about the use of commas at end of enumerator lists on C++03.
+#if defined __clang__
+# pragma clang diagnostic ignored "-Wc++11-extensions"
+#elif defined __GNUC__
+# if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))
+#  pragma GCC diagnostic ignored "-Wpedantic"
+# else
+#  pragma GCC diagnostic ignored "-pedantic"
+# endif
+#endif
+
 #include <qrencode.h>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 class QRCode
 {


### PR DESCRIPTION
Limited to a push or pull request that changes anything in the 3.0 directory. This could maybe be improved at some point, e.g., for the next version's modules to build against that branch as well.

Installs any additional dependencies (modules should include the PackageInfo directive if necessary).

Builds are based on the inspircd/inspircd insp3 branch and only build the necessary subset of modules:
- Pull Request: build any modules within the 3.0 directory that have been changed.
- Push: build all modules within the 3.0 directory.
