### PR TITLE
Fix a bunch of issues with roleplay.

### DIFF
--- a/3.0/m_roleplay.cpp
+++ b/3.0/m_roleplay.cpp
@@ -487,7 +487,7 @@ public:
 		/* Put the tags on as soon as possible just in case anything
 		 * wants to look at it.
 		 */
-		msgdetails.AddTag("inspircd.org/roleplay-msg", &roleplaymsgtag, user->nick);
+		msgdetails.AddTag("inspircd.org/roleplay-msg", &roleplaymsgtag, user->GetFullHost());
 		msgdetails.AddTag("inspircd.org/roleplay-src", &roleplaysrctag, source);
 
 		if(!CheckMessage(user, msgtarget, msgdetails))

--- a/3.0/m_roleplay.cpp
+++ b/3.0/m_roleplay.cpp
@@ -232,9 +232,14 @@ public:
 	}
 };
 
-/* We make a fake user class in the same vein as FakeUser, but not a server.
- * We just hope nobody looks too closely at it and finds the man behind the
- * curtain... :p
+/* We make a fake user class in the same vein as FakeUser, except UserType is
+ * set to zero. This is perfectly legal in C++, as an enumeration is guaranteed
+ * by the standard to hold any value with the same bit width as its largest
+ * member. Since no member in UserType is defined with 0, and since it's
+ * obviously smaller than any other enumeration value, IS_SERVER, IS_LOCAL, and
+ * IS_REMOTE will be none the wiser (none will return anything).
+ *
+ * --Elizafox
  */
 class RoleplayUser : public User
 {
@@ -242,7 +247,7 @@ class RoleplayUser : public User
 
 public:
 	RoleplayUser(const std::string& fakenick, const std::string& fakehost)
-		: User(fakeuid, ServerInstance->FakeClient->server, USERTYPE_SERVER)
+		: User(fakeuid, ServerInstance->FakeClient->server, static_cast<UserType>(0))
 		, fake_host(fakehost)
 	{
 		nick = fakenick;

--- a/3.0/m_roleplay.cpp
+++ b/3.0/m_roleplay.cpp
@@ -392,7 +392,7 @@ class CommandBaseRoleplay : public SplitCommand
 		/* Do the thing.
 		 * Tags should already have been added to msgdetails before we got here.
 		 */
-		ClientProtocol::Messages::Privmsg privmsg(user->GetFullHost(), c, msgdetails.text, MSG_PRIVMSG);
+		ClientProtocol::Messages::Privmsg privmsg(user, c, msgdetails.text, MSG_PRIVMSG);
 		privmsg.AddTags(msgdetails.tags_out);
 		c->Write(ServerInstance->GetRFCEvents().privmsg, privmsg);
 
@@ -495,14 +495,6 @@ public:
 		user->idle_lastmsg = ServerInstance->Time();
 
 		return CMD_SUCCESS;
-	}
-
-	RouteDescriptor GetRouting(User* user, const CommandBase::Params& parameters) CXX11_OVERRIDE
-	{
-		/* spanningtree will broadcast this as a PRIVMSG
-		 * It would be actively harmful to broadcast this.
-		 */
-		return ROUTE_LOCALONLY;
 	}
 };
 
@@ -825,8 +817,10 @@ public:
 
 		const std::string& src = tag->second.value;
 		if(src.empty())
-			// wtf?
-			throw ModuleException("Empty roleplay source tag received");
+		{
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Got an empty value in the inspircd.org/roleplay-src tag, this should not happen.");
+			return MOD_RES_DENY;
+		}
 
 		// We need to keep the source alive as long as this message is
 		lastsrc = src;

--- a/3.0/m_roleplay.cpp
+++ b/3.0/m_roleplay.cpp
@@ -310,7 +310,7 @@ public:
 /* This class does the heavy lifting of handling all the sending machinery. It
  * helps cut back heavily on code duplication.
  */
-class CommandBaseRoleplay : public Command
+class CommandBaseRoleplay : public SplitCommand
 {
 	SimpleChannelModeHandler& roleplaymode;
 	RoleplayMsgTag& roleplaymsgtag;
@@ -441,7 +441,7 @@ protected:
 
 public:
 	CommandBaseRoleplay(Module* Creator, const std::string& cmd, int params, RoleplayMode& mode, RoleplayMsgTag& tag_m, RoleplaySrcTag& tag_s)
-		: Command(Creator, cmd, params, params)
+		: SplitCommand(Creator, cmd, params, params)
 		, roleplaymode(mode)
 		, roleplaymsgtag(tag_m)
 		, roleplaysrctag(tag_s)
@@ -452,13 +452,8 @@ public:
 	/* Actually send out the message (or an error)
 	 * The machinery for transforming the message/source is in GetSource/GetMessage.
 	 */
-	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	CmdResult HandleLocal(LocalUser* user, const Params& parameters) CXX11_OVERRIDE
 	{
-		LocalUser* luser = IS_LOCAL(user);
-		if(!luser)
-			// This shouldn't happen.
-			return CMD_FAILURE;
-
 		Channel* c = ServerInstance->FindChan(parameters[0]);
 
 		if(c)
@@ -497,7 +492,7 @@ public:
 		SendMessage(user, c, source, msgtarget, msgdetails);
 
 		// Since this is a message, update the users' idle time.
-		luser->idle_lastmsg = ServerInstance->Time();
+		user->idle_lastmsg = ServerInstance->Time();
 
 		return CMD_SUCCESS;
 	}
@@ -641,7 +636,7 @@ public:
 		flags_needed = 'o';
 	}
 
-	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	CmdResult HandleLocal(LocalUser* user, const Params& parameters) CXX11_OVERRIDE
 	{
 		if(!user->HasPrivPermission("channels/roleplay"))
 		{
@@ -674,7 +669,7 @@ public:
 		flags_needed = 'o';
 	}
 
-	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	CmdResult HandleLocal(LocalUser* user, const Params& parameters) CXX11_OVERRIDE
 	{
 		if(!user->HasPrivPermission("channels/roleplay"))
 		{


### PR DESCRIPTION
**EDIT**: mention the new fixes for this.

Okay so @SadieCat gave me a good way to fix this. I took some pointers (and code) from the `m_ircv3_msgid`` module as well as her suggestions.

There are issues with the roleplay module as it stands with remote propagation: messages get duplicated, and history isn't played back correctly to clients; all roleplay commands look as if they came from the person who executed them. The reason for this is `m_spanningtree` hooks `OnUserPostMesage` to propagate messages and `m_chanhistory` uses this to store history. There are probably countless other things I missed, but those were the big two.

My first shake at this was to make a fake client class, but this could potentially cause issues as inspircd was not really designed to do this and it was a bit of a hack.

The latest commit in this branch rectifies the issues I mentioned above in another way, by using a special `inspircd.org/roleplay-src` tag that lets us rewrite things as we need to. This tag will never be seen by clients, it is simply for internal use. When we send out a user message, we now simply call `msg.SetSource()` on it to make it appear it came from us.

Previously, for posterity:
~~This is in a simlar vein to FakeUser, but inherits directly from User
since this isn't a server (although it pretends to be one, it's
ultimately just... us). This is good enough to fool most modules like
the history module and spanningtree module.

This fixes a bug where spanningtree would erroneously propagate roleplay
messages as if they came from the person who used the command. This also
happens to fix an issue where the chanhistory module would not save the
logs correctly from roleplay.~~