### PR TITLE
add m_canjoinban: matches users banned from a given channel

### DIFF
--- a/3.0/m_canjoinban.cpp
+++ b/3.0/m_canjoinban.cpp
@@ -1,0 +1,51 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2021 David Schultz <me@zpld.me>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+class ModuleBadChannelExtban : public Module
+{
+ public:
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Adds extended ban J: which checks whether users are banned from a certain channel.", VF_OPTCOMMON|VF_VENDOR);
+	}
+
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
+	{
+		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
+		{
+			std::string rm(mask, 2);
+			Channel* chan = ServerInstance->FindChan(rm);
+
+			if (chan && chan->IsBanned(user))
+			{
+				return MOD_RES_DENY;
+			}
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
+	{
+		tokens["EXTBAN"].push_back('J');
+	}
+};
+
+MODULE_INIT(ModuleBadChannelExtban)


### PR DESCRIPTION
Adds m_canjoinban. This provides the J:<channel> extban which checks if a user is banned from a channel. This is useful for communities that consist of multiple channels and want to have a global namespace ban list. For example, you could have `#inspircd` and `#inspircd.dev` and a `#inspircd.bans` channel with `+b J:#inspircd.bans` on the other two channels. Then, when a user tries to join `#inspircd` and they are banned in `#inspircd.bans`, they will not be permitted to enter the channel. This module is inspired by [extb_canjoin](https://github.com/solanum-ircd/solanum/blob/main/extensions/extb_canjoin.c) on solanum.