### PR TITLE
There's no reason extjwt module need to be a common module

### DIFF
--- a/3/m_ircv3_extjwt.cpp
+++ b/3/m_ircv3_extjwt.cpp
@@ -385,7 +385,7 @@ class ModuleIRCv3ExtJWT CXX11_FINAL
 
 	Version GetVersion() CXX11_OVERRIDE
 	{
-		return Version("Provides the DRAFT extjwt IRCv3 extension", VF_OPTCOMMON);
+		return Version("Provides the DRAFT extjwt IRCv3 extension", VF_NONE);
 	}
 };
 


### PR DESCRIPTION
I think there's no reason extjwt module need to be a common module. 