### PR TITLE
Add m_ircv3_preaway

### DIFF
--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -1,0 +1,43 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 reverse <mike.chevronnet@gmail.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: reverse <mike.chevronnet@gmail.com>
+/// $ModDepends: core 4
+/// $ModDesc: Provides the DRAFT pre-away IRCv3 extension.
+
+
+#include "inspircd.h"
+#include "modules/cap.h"
+
+class ModuleIRCv3PreAway final
+	: public Module
+{
+private:
+	Cap::Capability cap;
+
+public:
+	ModuleIRCv3PreAway()
+		: Module(VF_VENDOR, "Provides the IRCv3 draft/pre-away client capability.")
+		, cap(this, "draft/pre-away")
+	{
+		// CommandAway already sets works_before_reg, so a pre-away client can send
+		// AWAY mid-registration as-is; this just advertises that support.
+	}
+};
+
+MODULE_INIT(ModuleIRCv3PreAway)

--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -31,6 +31,7 @@ private:
 	Cap::Capability cap;
 	ClientProtocol::EventProvider awayprov;
 	std::string substitute;
+	bool sending = false; // set while re-sending a substituted AWAY, so it can't re-enter OnUserWrite
 
 public:
 	ModuleIRCv3PreAway()
@@ -42,6 +43,8 @@ public:
 
 	void ReadConfig(ConfigStatus&) override
 	{
+		// An away message can't be empty, so reject empty/over-length/"*" values
+		// and fall back to the default — substitute is then always usable.
 		substitute = ServerInstance->Config->ConfValue("preaway")->getString("substitute", "Away", [](const auto& str) {
 			return !str.empty() && str.length() <= ServerInstance->Config->Limits.MaxAway && !irc::equals(str, "*");
 		});
@@ -49,11 +52,21 @@ public:
 
 	ModResult OnUserWrite(LocalUser* user, ClientProtocol::Message& msg) override
 	{
-		if (substitute.empty() || cap.IsEnabled(user))
+		// draft/pre-away lets a client mark itself away without a message via
+		// "AWAY *". Clients that negotiated the cap understand the "*" and keep
+		// it; clients without it get the configured message substituted in. The
+		// guard stops the substituted AWAY we send below from re-entering here.
+		if (sending || cap.IsEnabled(user))
 			return MOD_RES_PASSTHRU;
 
+		// Cheap prefilter — only AWAY and the RPL_AWAY (301) numeric are relevant.
 		const char* cmd = msg.GetCommand();
 		if (cmd[0] != 'A' && cmd[0] != '3')
+			return MOD_RES_PASSTHRU;
+
+		const std::string command = cmd;
+		const bool isaway = command == "AWAY";
+		if (!isaway && command != "301")
 			return MOD_RES_PASSTHRU;
 
 		const auto& params = msg.GetParams();
@@ -64,26 +77,27 @@ public:
 		if (awaymsg != "*")
 			return MOD_RES_PASSTHRU;
 
-		const std::string command = cmd;
-		if (command == "301")
+		// RPL_AWAY (301) is a numeric built for this one user, so its parameter
+		// can be rewritten in place.
+		if (!isaway)
 		{
 			msg.ReplaceParam(params.size() - 1, substitute);
 			return MOD_RES_PASSTHRU;
 		}
 
-		if (command == "AWAY")
-		{
-			User* source = msg.GetSourceUser();
-			if (!source)
-				return MOD_RES_PASSTHRU;
+		// An away-notify AWAY is a single message broadcast to every channel
+		// member; mutating it would change it for cap clients too. Send this user
+		// their own substituted copy and drop the original.
+		User* source = msg.GetSourceUser();
+		if (!source)
+			return MOD_RES_PASSTHRU;
 
-			ClientProtocol::Message rewritten("AWAY", source);
-			rewritten.PushParam(substitute);
-			user->Send(awayprov, rewritten);
-			return MOD_RES_DENY;
-		}
-
-		return MOD_RES_PASSTHRU;
+		ClientProtocol::Message rewritten("AWAY", source);
+		rewritten.PushParam(substitute);
+		sending = true;
+		user->Send(awayprov, rewritten);
+		sending = false;
+		return MOD_RES_DENY;
 	}
 };
 

--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -17,9 +17,9 @@
  */
 
 /// $ModAuthor: reverse <mike.chevronnet@gmail.com>
+/// $ModConfig: <preaway substitute="Away">
 /// $ModDepends: core 4
-/// $ModDesc: Provides the DRAFT pre-away IRCv3 extension.
-
+/// $ModDesc: Provides the DRAFT draft/pre-away IRCv3 client capability.
 
 #include "inspircd.h"
 #include "modules/cap.h"
@@ -29,14 +29,60 @@ class ModuleIRCv3PreAway final
 {
 private:
 	Cap::Capability cap;
+	ClientProtocol::EventProvider awayprov;
+	std::string substitute;
 
 public:
 	ModuleIRCv3PreAway()
-		: Module(VF_VENDOR, "Provides the IRCv3 draft/pre-away client capability.")
+		: Module(VF_VENDOR, "Provides the DRAFT draft/pre-away IRCv3 client capability.")
 		, cap(this, "draft/pre-away")
+		, awayprov(this, "AWAY")
 	{
-		// CommandAway already sets works_before_reg, so a pre-away client can send
-		// AWAY mid-registration as-is; this just advertises that support.
+	}
+
+	void ReadConfig(ConfigStatus&) override
+	{
+		const std::string sub = ServerInstance->Config->ConfValue("preaway")->getString("substitute", "Away");
+		substitute = (sub == "*") ? "" : sub;
+	}
+
+	ModResult OnUserWrite(LocalUser* user, ClientProtocol::Message& msg) override
+	{
+		if (substitute.empty() || cap.IsEnabled(user))
+			return MOD_RES_PASSTHRU;
+
+		const char* cmd = msg.GetCommand();
+		if (cmd[0] != 'A' && cmd[0] != '3')
+			return MOD_RES_PASSTHRU;
+
+		const auto& params = msg.GetParams();
+		if (params.empty())
+			return MOD_RES_PASSTHRU;
+
+		const std::string& awaymsg = params.back();
+		if (awaymsg != "*")
+			return MOD_RES_PASSTHRU;
+
+		const std::string command = cmd;
+		if (command == "301")
+		{
+			msg.ReplaceParam(params.size() - 1, substitute);
+			return MOD_RES_PASSTHRU;
+		}
+
+		if (command == "AWAY")
+		{
+			User* source = msg.GetSourceUser();
+			if (!source)
+				return MOD_RES_PASSTHRU;
+
+			ClientProtocol::Message rewritten("AWAY", source);
+			rewritten.PushParam(substitute);
+			user->Send(awayprov, rewritten);
+			return MOD_RES_DENY;
+		}
+
+		return MOD_RES_PASSTHRU;
 	}
 };
 

--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -17,58 +17,27 @@
  */
 
 /// $ModAuthor: reverse <mike.chevronnet@gmail.com>
-/// $ModConfig: <preaway substitute="Away">
 /// $ModDepends: core 4
-/// $ModDesc: Provides the DRAFT draft/pre-away IRCv3 client capability.
+/// $ModDesc: Provides the DRAFT pre-away IRCv3 extension.
 
 
 #include "inspircd.h"
-#include "modules/away.h"
 #include "modules/cap.h"
 
 class ModuleIRCv3PreAway final
 	: public Module
-	, public Away::EventListener
 {
 private:
 	Cap::Capability cap;
-	std::string substitute;
 
 public:
 	ModuleIRCv3PreAway()
-		: Module(VF_VENDOR, "Provides the DRAFT draft/pre-away IRCv3 client capability.")
-		, Away::EventListener(this)
+		: Module(VF_VENDOR, "Provides the IRCv3 draft/pre-away client capability.")
 		, cap(this, "draft/pre-away")
 	{
 		// CommandAway already sets works_before_reg, so a pre-away client can send
-		// AWAY mid-registration as-is; advertising the cap is most of the job. The
-		// one extra bit of behaviour the spec asks for is the "*" handling below.
+		// AWAY mid-registration as-is; this just advertises that support.
 	}
-
-	void ReadConfig(ConfigStatus&) override
-	{
-		// What to relay in place of a bare "*" away message. Leaving this empty keeps
-		// the literal "*" on the wire (the spec only says servers MAY substitute).
-		substitute = ServerInstance->Config->ConfValue("preaway")->getString("substitute", "Away");
-	}
-
-	ModResult OnUserPreAway(LocalUser*, std::string& message) override
-	{
-		// draft/pre-away gives "*" a special meaning: the user is away but isn't
-		// saying why. The spec lets the server swap in a human-readable string before
-		// that gets relayed to other clients, which is what we do here.
-		//
-		// The spec note about "*" not overriding an away message set by another of the
-		// user's connections doesn't apply to us: InspIRCd tracks away state per
-		// connection, so there's no shared session to clobber.
-		if (!substitute.empty() && message == "*")
-			message = substitute;
-		return MOD_RES_PASSTHRU;
-	}
-
-	// We only care about the pre-away rewrite; these are required but unused.
-	void OnUserAway(User*, const std::optional<AwayState>&) override { }
-	void OnUserBack(User*, const std::optional<AwayState>&) override { }
 };
 
 MODULE_INIT(ModuleIRCv3PreAway)

--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -17,27 +17,58 @@
  */
 
 /// $ModAuthor: reverse <mike.chevronnet@gmail.com>
+/// $ModConfig: <preaway substitute="Away">
 /// $ModDepends: core 4
-/// $ModDesc: Provides the DRAFT pre-away IRCv3 extension.
+/// $ModDesc: Provides the DRAFT draft/pre-away IRCv3 client capability.
 
 
 #include "inspircd.h"
+#include "modules/away.h"
 #include "modules/cap.h"
 
 class ModuleIRCv3PreAway final
 	: public Module
+	, public Away::EventListener
 {
 private:
 	Cap::Capability cap;
+	std::string substitute;
 
 public:
 	ModuleIRCv3PreAway()
-		: Module(VF_VENDOR, "Provides the IRCv3 draft/pre-away client capability.")
+		: Module(VF_VENDOR, "Provides the DRAFT draft/pre-away IRCv3 client capability.")
+		, Away::EventListener(this)
 		, cap(this, "draft/pre-away")
 	{
 		// CommandAway already sets works_before_reg, so a pre-away client can send
-		// AWAY mid-registration as-is; this just advertises that support.
+		// AWAY mid-registration as-is; advertising the cap is most of the job. The
+		// one extra bit of behaviour the spec asks for is the "*" handling below.
 	}
+
+	void ReadConfig(ConfigStatus&) override
+	{
+		// What to relay in place of a bare "*" away message. Leaving this empty keeps
+		// the literal "*" on the wire (the spec only says servers MAY substitute).
+		substitute = ServerInstance->Config->ConfValue("preaway")->getString("substitute", "Away");
+	}
+
+	ModResult OnUserPreAway(LocalUser*, std::string& message) override
+	{
+		// draft/pre-away gives "*" a special meaning: the user is away but isn't
+		// saying why. The spec lets the server swap in a human-readable string before
+		// that gets relayed to other clients, which is what we do here.
+		//
+		// The spec note about "*" not overriding an away message set by another of the
+		// user's connections doesn't apply to us: InspIRCd tracks away state per
+		// connection, so there's no shared session to clobber.
+		if (!substitute.empty() && message == "*")
+			message = substitute;
+		return MOD_RES_PASSTHRU;
+	}
+
+	// We only care about the pre-away rewrite; these are required but unused.
+	void OnUserAway(User*, const std::optional<AwayState>&) override { }
+	void OnUserBack(User*, const std::optional<AwayState>&) override { }
 };
 
 MODULE_INIT(ModuleIRCv3PreAway)

--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -34,7 +34,7 @@ private:
 
 public:
 	ModuleIRCv3PreAway()
-		: Module(VF_VENDOR, "Provides the DRAFT draft/pre-away IRCv3 client capability.")
+		: Module(VF_NONE, "Provides the DRAFT draft/pre-away IRCv3 client capability.")
 		, cap(this, "draft/pre-away")
 		, awayprov(this, "AWAY")
 	{

--- a/4/m_ircv3_preaway.cpp
+++ b/4/m_ircv3_preaway.cpp
@@ -42,8 +42,9 @@ public:
 
 	void ReadConfig(ConfigStatus&) override
 	{
-		const std::string sub = ServerInstance->Config->ConfValue("preaway")->getString("substitute", "Away");
-		substitute = (sub == "*") ? "" : sub;
+		substitute = ServerInstance->Config->ConfValue("preaway")->getString("substitute", "Away", [](const auto& str) {
+			return !str.empty() && str.length() <= ServerInstance->Config->Limits.MaxAway && !irc::equals(str, "*");
+		});
 	}
 
 	ModResult OnUserWrite(LocalUser* user, ClientProtocol::Message& msg) override


### PR DESCRIPTION
> Adds m_ircv3_preaway, implementing draft/pre-away (https://ircv3.net/specs/extensions/pre-away). CommandAway already sets works_before_reg, so the server accepts AWAY during registration as-is — this just advertises the cap. Tested: cap shows in CAP LS; AWAY :x before CAP END returns 306; post-registration WHOIS shows 301 :x. Draft, happy to iterate.
