### PR TITLE
Add m_conn_matchgecos & port various v3 -> v4 modules

### DIFF
--- a/4/m_antirandom.cpp
+++ b/4/m_antirandom.cpp
@@ -1,0 +1,844 @@
+/*       +------------------------------------+
+ *       | Inspire Internet Relay Chat Daemon |
+ *       +------------------------------------+
+ *
+ *  InspIRCd: (C) 2002-2011 InspIRCd Development Team
+ * See: http://www.inspircd.org/wiki/index.php/Credits
+ *
+ * This program is free but copyrighted software; see
+ *            the file COPYING for details.
+ *
+ * (C) Copyright 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *     - Upgraded to InspIRCd v4
+ *     - Renamed references of "ident" to "realuser" in accordance with v4 changes
+ * (C) Copyright 2016 linuxdaemon <linuxdaemonirc@gmail.com>
+ *     - Fixed pointer dereference issues in the score calculations
+ *     - Rewrote the consonant/vowel switches to use strchr()
+ *     - Changed the calculation function to use std::string instead of a c-ctring
+ *     - Migrated to using a std::map rather than blindly iterating over a whole array
+ * (C) Copyright 2013 SimosNap IRC Network <admin@simosnap.org>
+ *                    lnx85 <lnx85@lnxlabs.it>
+ *     - Added exempt support (nick, ident, host and fullname based)
+ * (C) Copyright 2011 Syloq <syloq@nightstar.net>
+ *     - Renamed failedconnects to showfailedconnects
+ *     - Added example config and notes
+ *     - Added defaults to all parameters
+ * (C) Copyright 2008 Robin Burchell <w00t@inspircd.org>
+ * (C) Copyright 2004-2005, Bram Matthys (Syzop) <syzop@vulnscan.org>
+ *     - Contains ideas from Keith Dunnett <keith@dunnett.org>
+ *     - Most of the detection mechanisms come from SpamAssassin FVGT_Tripwire.
+ * ---------------------------------------------------
+ * Example config:
+   <antirandom
+        showfailedconnects="1" (Defaults to 1 )
+        debugmode="0" (Defaults to 0)
+        threshold="10" (Defaults to 10 Valid values between 1 and 100)
+        banaction="ZLINE" (Defaults to "" Valid values: GLINE,ZLINE,KILL,"")
+        banduration="86400" (Defaults to 86400 (1 day). Time in seconds)
+        banreason="You look like a bot. Change your nick/ident/gecos and try reconnecting.">
+   <antirandomexempt type="host" pattern="*.tld">
+   <antirandomexempt type="realuser" pattern="*lightirc">
+   <antirandomexempt type="fullname" pattern="Mibbit">
+
+   Notes:
+        showfailedconnects - Show failed connection
+        This module uses a scoring system that will react based
+         on the threshold set above. If the threshold is set too low many
+         clients will be tagged a bot.
+ */
+
+#include "inspircd.h"
+#include "xline.h"
+
+/// $ModDesc: A module to prevent against bots using random patterns.
+/// $ModAuthor: lnx85
+/// $ModAuthorMail: lnx85@lnxlabs.it
+/// $ModDepends: core 4
+
+#define ANTIRANDOM_ACT_KILL     0
+#define ANTIRANDOM_ACT_ZLINE    1
+#define ANTIRANDOM_ACT_GLINE    2
+#define ANTIRANDOM_ACT_NONE     3
+
+enum AntirandomExemptType { NICK, REALUSER, HOST, FULLNAME };
+
+class AntirandomExempt
+{
+public:
+	AntirandomExemptType type;
+	std::string pattern;
+
+	AntirandomExempt(AntirandomExemptType t, const std::string &p)
+	: type(t), pattern(p)
+	{
+	}
+};
+typedef std::vector<AntirandomExempt> AntirandomExemptList;
+
+static const char *triples_txt[] = {
+	"aj", "fqtvxz",
+	"aq", "deghjkmnprtxyz",
+	"av", "bfhjqwxz",
+	"az", "jwx",
+	"bd", "bghjkmpqvxz",
+	"bf", "bcfgjknpqvwxyz",
+	"bg", "bdfghjkmnqstvxz",
+	"bh", "bfhjkmnqvwxz",
+	"bj", "bcdfghjklmpqtvwxyz",
+	"bk", "dfjkmqrvwxyz",
+	"bl", "bgpqwxz",
+	"bm", "bcdflmnqz",
+	"bn", "bghjlmnpqtvwx",
+	"bp", "bfgjknqvxz",
+	"bq", "bcdefghijklmnopqrstvwxyz",
+	"bt", "dgjkpqtxz",
+	"bv", "bfghjklnpqsuvwxz",
+	"bw", "bdfjknpqsuwxyz",
+	"bx", "abcdfghijklmnopqtuvwxyz",
+	"bz", "bcdfgjklmnpqrstvwxz",
+	"cb", "bfghjkpqyz",
+	"cc", "gjqxz",
+	"cd", "hjkqvwxz",
+	"cf", "gjknqvwyz",
+	"cg", "bdfgjkpqvz",
+	"cl", "fghjmpqxz",
+	"cm", "bjkqv",
+	"cn", "bghjkpqwxz",
+	"cp", "gjkvxyz",
+	"cq", "abcdefghijklmnopqsvwxyz",
+	"cr", "gjqx",
+	"cs", "gjxz",
+	"cv", "bdfghjklmnquvwxyz",
+	"cx", "abdefghjklmnpqrstuvwxyz",
+	"cy", "jqy",
+	"cz", "bcdfghjlpqrtvwxz",
+	"db", "bdgjnpqtxz",
+	"dc", "gjqxz",
+	"dd", "gqz",
+	"df", "bghjknpqvxyz",
+	"dg", "bfgjqvxz",
+	"dh", "bfkmnqwxz",
+	"dj", "bdfghjklnpqrwxz",
+	"dk", "cdhjkpqrtuvwxz",
+	"dl", "bfhjknqwxz",
+	"dm", "bfjnqw",
+	"dn", "fgjkmnpqvwz",
+	"dp", "bgjkqvxz",
+	"dq", "abcefghijkmnopqtvwxyz",
+	"dr", "bfkqtvx",
+	"dt", "qtxz",
+	"dv", "bfghjknqruvwyz",
+	"dw", "cdfjkmnpqsvwxz",
+	"dx", "abcdeghjklmnopqrsuvwxyz",
+	"dy", "jyz",
+	"dz", "bcdfgjlnpqrstvxz",
+	"eb", "jqx",
+	"eg", "cjvxz",
+	"eh", "hxz",
+	"ej", "fghjpqtwxyz",
+	"ek", "jqxz",
+	"ep", "jvx",
+	"eq", "bcghijkmotvxyz",
+	"ev", "bfpq",
+	"fc", "bdjkmnqvxz",
+	"fd", "bgjklqsvyz",
+	"fg", "fgjkmpqtvwxyz",
+	"fh", "bcfghjkpqvwxz",
+	"fj", "bcdfghijklmnpqrstvwxyz",
+	"fk", "bcdfghjkmpqrstvwxz",
+	"fl", "fjkpqxz",
+	"fm", "dfhjlmvwxyz",
+	"fn", "bdfghjklnqrstvwxz",
+	"fp", "bfjknqtvwxz",
+	"fq", "abcefghijklmnopqrstvwxyz",
+	"fr", "nqxz",
+	"fs", "gjxz",
+	"ft", "jqx",
+	"fv", "bcdfhjklmnpqtuvwxyz",
+	"fw", "bcfgjklmpqstuvwxyz",
+	"fx", "bcdfghjklmnpqrstvwxyz",
+	"fy", "ghjpquvxy",
+	"fz", "abcdfghjklmnpqrtuvwxyz",
+	"gb", "bcdknpqvwx",
+	"gc", "gjknpqwxz",
+	"gd", "cdfghjklmqtvwxz",
+	"gf", "bfghjkmnpqsvwxyz",
+	"gg", "jkqvxz",
+	"gj", "bcdfghjklmnpqrstvwxyz",
+	"gk", "bcdfgjkmpqtvwxyz",
+	"gl", "fgjklnpqwxz",
+	"gm", "dfjkmnqvxz",
+	"gn", "jkqvxz",
+	"gp", "bjknpqtwxyz",
+	"gq", "abcdefghjklmnopqrsvwxyz",
+	"gr", "jkqt",
+	"gt", "fjknqvx",
+	"gu", "qwx",
+	"gv", "bcdfghjklmpqstvwxyz",
+	"gw", "bcdfgjknpqtvwxz",
+	"gx", "abcdefghjklmnopqrstvwxyz",
+	"gy", "jkqxy",
+	"gz", "bcdfgjklmnopqrstvxyz",
+	"hb", "bcdfghjkqstvwxz",
+	"hc", "cjknqvwxz",
+	"hd", "fgjnpvz",
+	"hf", "bfghjkmnpqtvwxyz",
+	"hg", "bcdfgjknpqsxyz",
+	"hh", "bcgklmpqrtvwxz",
+	"hj", "bcdfgjkmpqtvwxyz",
+	"hk", "bcdgkmpqrstvwxz",
+	"hl", "jxz",
+	"hm", "dhjqrvwxz",
+	"hn", "jrxz",
+	"hp", "bjkmqvwxyz",
+	"hq", "abcdefghijklmnopqrstvwyz",
+	"hr", "cjqx",
+	"hs", "jqxz",
+	"hv", "bcdfgjklmnpqstuvwxz",
+	"hw", "bcfgjklnpqsvwxz",
+	"hx", "abcdefghijklmnopqrstuvwxyz",
+	"hz", "bcdfghjklmnpqrstuvwxz",
+	"ib", "jqx",
+	"if", "jqvwz",
+	"ih", "bgjqx",
+	"ii", "bjqxy",
+	"ij", "cfgqxy",
+	"ik", "bcfqx",
+	"iq", "cdefgjkmnopqtvxyz",
+	"iu", "hiwxy",
+	"iv", "cfgmqx",
+	"iw", "dgjkmnpqtvxz",
+	"ix", "jkqrxz",
+	"iy", "bcdfghjklpqtvwx",
+	"jb", "bcdghjklmnopqrtuvwxyz",
+	"jc", "cfgjkmnopqvwxy",
+	"jd", "cdfghjlmnpqrtvwx",
+	"jf", "abcdfghjlnopqrtuvwxyz",
+	"jg", "bcdfghijklmnopqstuvwxyz",
+	"jh", "bcdfghjklmnpqrxyz",
+	"jj", "bcdfghjklmnopqrstuvwxyz",
+	"jk", "bcdfghjknqrtwxyz",
+	"jl", "bcfghjmnpqrstuvwxyz",
+	"jm", "bcdfghiklmnqrtuvwyz",
+	"jn", "bcfjlmnpqsuvwxz",
+	"jp", "bcdfhijkmpqstvwxyz",
+	"jq", "abcdefghijklmnopqrstuvwxyz",
+	"jr", "bdfhjklpqrstuvwxyz",
+	"js", "bfgjmoqvxyz",
+	"jt", "bcdfghjlnpqrtvwxz",
+	"jv", "abcdfghijklpqrstvwxyz",
+	"jw", "bcdefghijklmpqrstuwxyz",
+	"jx", "abcdefghijklmnopqrstuvwxyz",
+	"jy", "bcdefghjkpqtuvwxyz",
+	"jz", "bcdfghijklmnopqrstuvwxyz",
+	"kb", "bcdfghjkmqvwxz",
+	"kc", "cdfgjknpqtwxz",
+	"kd", "bfghjklmnpqsvwxyz",
+	"kf", "bdfghjkmnpqsvwxyz",
+	"kg", "cghjkmnqtvwxyz",
+	"kh", "cfghjkqx",
+	"kj", "bcdfghjkmnpqrstwxyz",
+	"kk", "bcdfgjmpqswxz",
+	"kl", "cfghlmqstwxz",
+	"km", "bdfghjknqrstwxyz",
+	"kn", "bcdfhjklmnqsvwxz",
+	"kp", "bdfgjkmpqvxyz",
+	"kq", "abdefghijklmnopqrstvwxyz",
+	"kr", "bcdfghjmqrvwx",
+	"ks", "jqx",
+	"kt", "cdfjklqvx",
+	"ku", "qux",
+	"kv", "bcfghjklnpqrstvxyz",
+	"kw", "bcdfgjklmnpqsvwxz",
+	"kx", "abcdefghjklmnopqrstuvwxyz",
+	"ky", "vxy",
+	"kz", "bcdefghjklmnpqrstuvwxyz",
+	"lb", "cdgkqtvxz",
+	"lc", "bqx",
+	"lg", "cdfgpqvxz",
+	"lh", "cfghkmnpqrtvx",
+	"lk", "qxz",
+	"ln", "cfjqxz",
+	"lp", "jkqxz",
+	"lq", "bcdefhijklmopqrstvwxyz",
+	"lr", "dfgjklmpqrtvwx",
+	"lv", "bcfhjklmpwxz",
+	"lw", "bcdfgjknqxz",
+	"lx", "bcdfghjklmnpqrtuwz",
+	"lz", "cdjptvxz",
+	"mb", "qxz",
+	"md", "hjkpvz",
+	"mf", "fkpqvwxz",
+	"mg", "cfgjnpqsvwxz",
+	"mh", "bchjkmnqvx",
+	"mj", "bcdfghjknpqrstvwxyz",
+	"mk", "bcfgklmnpqrvwxz",
+	"ml", "jkqz",
+	"mm", "qvz",
+	"mn", "fhjkqxz",
+	"mq", "bdefhjklmnopqtwxyz",
+	"mr", "jklqvwz",
+	"mt", "jkq",
+	"mv", "bcfghjklmnqtvwxz",
+	"mw", "bcdfgjklnpqsuvwxyz",
+	"mx", "abcefghijklmnopqrstvwxyz",
+	"mz", "bcdfghjkmnpqrstvwxz",
+	"nb", "hkmnqxz",
+	"nf", "bghqvxz",
+	"nh", "fhjkmqtvxz",
+	"nk", "qxz",
+	"nl", "bghjknqvwxz",
+	"nm", "dfghjkqtvwxz",
+	"np", "bdjmqwxz",
+	"nq", "abcdfghjklmnopqrtvwxyz",
+	"nr", "bfjkqstvx",
+	"nv", "bcdfgjkmnqswxz",
+	"nw", "dgjpqvxz",
+	"nx", "abfghjknopuyz",
+	"nz", "cfqrxz",
+	"oc", "fjvw",
+	"og", "qxz",
+	"oh", "fqxz",
+	"oj", "bfhjmqrswxyz",
+	"ok", "qxz",
+	"oq", "bcdefghijklmnopqrstvwxyz",
+	"ov", "bfhjqwx",
+	"oy", "qxy",
+	"oz", "fjpqtvx",
+	"pb", "fghjknpqvwz",
+	"pc", "gjq",
+	"pd", "bgjkvwxz",
+	"pf", "hjkmqtvwyz",
+	"pg", "bdfghjkmqsvwxyz",
+	"ph", "kqvx",
+	"pk", "bcdfhjklmpqrvx",
+	"pl", "ghkqvwx",
+	"pm", "bfhjlmnqvwyz",
+	"pn", "fjklmnqrtvwz",
+	"pp", "gqwxz",
+	"pq", "abcdefghijklmnopqstvwxyz",
+	"pr", "hjkqrwx",
+	"pt", "jqxz",
+	"pv", "bdfghjklquvwxyz",
+	"pw", "fjkmnpqsuvwxz",
+	"px", "abcdefghijklmnopqrstuvwxyz",
+	"pz", "bdefghjklmnpqrstuvwxyz",
+	"qa", "ceghkopqxy",
+	"qb", "bcdfghjklmnqrstuvwxyz",
+	"qc", "abcdfghijklmnopqrstuvwxyz",
+	"qd", "defghijklmpqrstuvwxyz",
+	"qe", "abceghjkmopquwxyz",
+	"qf", "abdfghijklmnopqrstuvwxyz",
+	"qg", "abcdefghijklmnopqrtuvwxz",
+	"qh", "abcdefghijklmnopqrstuvwxyz",
+	"qi", "efgijkmpwx",
+	"qj", "abcdefghijklmnopqrstuvwxyz",
+	"qk", "abcdfghijklmnopqrsuvwxyz",
+	"ql", "abcefghjklmnopqrtuvwxyz",
+	"qm", "bdehijklmnoqrtuvxyz",
+	"qn", "bcdefghijklmnoqrtuvwxyz",
+	"qo", "abcdefgijkloqstuvwxyz",
+	"qp", "abcdefghijkmnopqrsuvwxyz",
+	"qq", "bcdefghijklmnopstwxyz",
+	"qr", "bdefghijklmnoqruvwxyz",
+	"qs", "bcdefgijknqruvwxz",
+	"qt", "befghjklmnpqtuvwxz",
+	"qu", "cfgjkpwz",
+	"qv", "abdefghjklmnopqrtuvwxyz",
+	"qw", "bcdfghijkmnopqrstuvwxyz",
+	"qx", "abcdefghijklmnopqrstuvwxyz",
+	"qy", "abcdefghjklmnopqrstuvwxyz",
+	"qz", "abcdefghijklmnopqrstuvwxyz",
+	"rb", "fxz",
+	"rg", "jvxz",
+	"rh", "hjkqrxz",
+	"rj", "bdfghjklmpqrstvwxz",
+	"rk", "qxz",
+	"rl", "jnq",
+	"rp", "jxz",
+	"rq", "bcdefghijklmnopqrtvwxy",
+	"rr", "jpqxz",
+	"rv", "bcdfghjmpqrvwxz",
+	"rw", "bfgjklqsvxz",
+	"rx", "bcdfgjkmnopqrtuvwxz",
+	"rz", "djpqvxz",
+	"sb", "kpqtvxz",
+	"sd", "jqxz",
+	"sf", "bghjkpqw",
+	"sg", "cgjkqvwxz",
+	"sj", "bfghjkmnpqrstvwxz",
+	"sk", "qxz",
+	"sl", "gjkqwxz",
+	"sm", "fkqwxz",
+	"sn", "dhjknqvwxz",
+	"sq", "bfghjkmopstvwxz",
+	"sr", "jklqrwxz",
+	"sv", "bfhjklmnqtwxyz",
+	"sw", "jkpqvwxz",
+	"sx", "bcdefghjklmnopqrtuvwxyz",
+	"sy", "qxy",
+	"sz", "bdfgjpqsvxz",
+	"tb", "cghjkmnpqtvwx",
+	"tc", "jnqvx",
+	"td", "bfgjkpqtvxz",
+	"tf", "ghjkqvwyz",
+	"tg", "bdfghjkmpqsx",
+	"tj", "bdfhjklmnpqstvwxyz",
+	"tk", "bcdfghjklmpqvwxz",
+	"tl", "jkqwxz",
+	"tm", "bknqtwxz",
+	"tn", "fhjkmqvwxz",
+	"tp", "bjpqvwxz",
+	"tq", "abdefhijklmnopqrstvwxyz",
+	"tr", "gjqvx",
+	"tv", "bcfghjknpquvwxz",
+	"tw", "bcdfjknqvz",
+	"tx", "bcdefghjklmnopqrsuvwxz",
+	"tz", "jqxz",
+	"uc", "fjmvx",
+	"uf", "jpqvx",
+	"ug", "qvx",
+	"uh", "bcgjkpvxz",
+	"uj", "wbfghklmqvwx",
+	"uk", "fgqxz",
+	"uq", "bcdfghijklmnopqrtwxyz",
+	"uu", "fijkqvwyz",
+	"uv", "bcdfghjkmpqtwxz",
+	"uw", "dgjnquvxyz",
+	"ux", "jqxz",
+	"uy", "jqxyz",
+	"uz", "fgkpqrx",
+	"vb", "bcdfhijklmpqrtuvxyz",
+	"vc", "bgjklnpqtvwxyz",
+	"vd", "bdghjklnqvwxyz",
+	"vf", "bfghijklmnpqtuvxz",
+	"vg", "bcdgjkmnpqtuvwxyz",
+	"vh", "bcghijklmnpqrtuvwxyz",
+	"vj", "abcdfghijklmnpqrstuvwxyz",
+	"vk", "bcdefgjklmnpqruvwxyz",
+	"vl", "hjkmpqrvwxz",
+	"vm", "bfghjknpquvxyz",
+	"vn", "bdhjkmnpqrtuvwxz",
+	"vp", "bcdeghjkmopqtuvwyz",
+	"vq", "abcdefghijklmnopqrstvwxyz",
+	"vr", "fghjknqrtvwxz",
+	"vs", "dfgjmqz",
+	"vt", "bdfgjklmnqtx",
+	"vu", "afhjquwxy",
+	"vv", "cdfghjkmnpqrtuwxz",
+	"vw", "abcdefghijklmnopqrtuvwxyz",
+	"vx", "abcefghjklmnopqrstuvxyz",
+	"vy", "oqx",
+	"vz", "abcdefgjklmpqrstvwxyz",
+	"wb", "bdfghjpqtvxz",
+	"wc", "bdfgjkmnqvwx",
+	"wd", "dfjpqvxz",
+	"wf", "cdghjkmqvwxyz",
+	"wg", "bcdfgjknpqtvwxyz",
+	"wh", "cdghjklpqvwxz",
+	"wj", "bfghijklmnpqrstvwxyz",
+	"wk", "cdfgjkpqtuvxz",
+	"wl", "jqvxz",
+	"wm", "dghjlnqtvwxz",
+	"wp", "dfgjkpqtvwxz",
+	"wq", "abcdefghijklmnopqrstvwxyz",
+	"wr", "cfghjlmpqwx",
+	"wt", "bdgjlmnpqtvx",
+	"wu", "aikoquvwy",
+	"wv", "bcdfghjklmnpqrtuvwxyz",
+	"ww", "bcdgkpqstuvxyz",
+	"wx", "abcdefghijklmnopqrstuvwxz",
+	"wy", "jquwxy",
+	"wz", "bcdfghjkmnopqrstuvwxz",
+	"xa", "ajoqy",
+	"xb", "bcdfghjkmnpqsvwxz",
+	"xc", "bcdgjkmnqsvwxz",
+	"xd", "bcdfghjklnpqstuvwxyz",
+	"xf", "bcdfghjkmnpqtvwxyz",
+	"xg", "bcdfghjkmnpqstvwxyz",
+	"xh", "cdfghjkmnpqrstvwxz",
+	"xi", "jkqy",
+	"xj", "abcdefghijklmnopqrstvwxyz",
+	"xk", "abcdfghjkmnopqrstuvwxyz",
+	"xl", "bcdfghjklmnpqrvwxz",
+	"xm", "bcdfghjknpqvwxz",
+	"xn", "bcdfghjklmnpqrvwxyz",
+	"xp", "bcfjknpqvxz",
+	"xq", "abcdefghijklmnopqrstvwxyz",
+	"xr", "bcdfghjklnpqrsvwyz",
+	"xs", "bdfgjmnqrsvxz",
+	"xt", "jkpqvwxz",
+	"xu", "fhjkquwx",
+	"xv", "bcdefghjklmnpqrsuvwxyz",
+	"xw", "bcdfghjklmnpqrtuvwxyz",
+	"xx", "bcdefghjkmnpqrstuwyz",
+	"xy", "jxy",
+	"xz", "abcdefghjklmnpqrstuvwxyz",
+	"yb", "cfghjmpqtvwxz",
+	"yc", "bdfgjmpqsvwx",
+	"yd", "chjkpqvwx",
+	"yf", "bcdghjmnpqsvwx",
+	"yg", "cfjkpqtxz",
+	"yh", "bcdfghjkpqx",
+	"yi", "hjqwxy",
+	"yj", "bcdfghjklmnpqrstvwxyz",
+	"yk", "bcdfgpqvwxz",
+	"ym", "dfgjqvxz",
+	"yp", "bcdfgjkmqxz",
+	"yq", "abcdefghijklmnopqrstvwxyz",
+	"yr", "jqx",
+	"yt", "bcfgjnpqx",
+	"yv", "bcdfghjlmnpqstvwxz",
+	"yw", "bfgjklmnpqstuvwxz",
+	"yx", "bcdfghjknpqrstuvwxz",
+	"yy", "bcdfghjklpqrstvwxz",
+	"yz", "bcdfjklmnpqtvwx",
+	"zb", "dfgjklmnpqstvwxz",
+	"zc", "bcdfgjmnpqstvwxy",
+	"zd", "bcdfghjklmnpqstvwxy",
+	"zf", "bcdfghijkmnopqrstvwxyz",
+	"zg", "bcdfgjkmnpqtvwxyz",
+	"zh", "bcfghjlpqstvwxz",
+	"zj", "abcdfghjklmnpqrstuvwxyz",
+	"zk", "bcdfghjklmpqstvwxz",
+	"zl", "bcdfghjlnpqrstvwxz",
+	"zm", "bdfghjklmpqstvwxyz",
+	"zn", "bcdfghjlmnpqrstuvwxz",
+	"zp", "bcdfhjklmnpqstvwxz",
+	"zq", "abcdefghijklmnopqrstvwxyz",
+	"zr", "bcfghjklmnpqrstvwxyz",
+	"zs", "bdfgjmnqrsuwxyz",
+	"zt", "bcdfgjkmnpqtuvwxz",
+	"zu", "ajqx",
+	"zv", "bcdfghjklmnpqrstuvwxyz",
+	"zw", "bcdfghjklmnpqrstuvwxyz",
+	"zx", "abcdefghijklmnopqrstuvwxyz",
+	"zy", "fxy",
+	"zz", "cdfhjnpqrvx",
+	NULL, NULL
+};
+
+static std::map<std::string, std::string> init_map(const char **a)
+{
+	std::map<std::string, std::string> m;
+	for (const char **ci = a; *ci; ci += 2)
+	{
+		m.insert(std::pair<std::string, std::string>(ci[0], ci[1]));
+	}
+	return m;
+}
+
+const static std::map<std::string, std::string> triples_map = init_map(triples_txt);
+
+class ModuleAntiRandom : public Module
+{
+ private:
+	bool ShowFailedConnects;
+	bool DebugMode;
+	unsigned int Threshold;
+	unsigned int BanAction;
+	unsigned int BanDuration;
+	std::string BanReason;
+	AntirandomExemptList Exempts;
+ public:
+	ModuleAntiRandom() : Module(VF_NONE, "A module to prevent against bots using random patterns")
+	{
+	}
+
+	unsigned int GetStringScore(const std::string &original_str)
+	{
+		unsigned int score = 0;
+
+		unsigned int highest_vowels = 0;
+		unsigned int highest_consonants = 0;
+		unsigned int highest_digits = 0;
+
+		unsigned int vowels = 0;
+		unsigned int consonants = 0;
+		unsigned int digits = 0;
+
+		/* Fast digit/consonant/vowel checks... */
+		for (size_t i = 0; i < original_str.length(); i++)
+		{
+			const char &c = original_str[i];
+			if ((c >= '0') && (c <= '9'))
+			{
+				digits++;
+			}
+			else
+			{
+				if (digits > highest_digits)
+					highest_digits = digits;
+				digits = 0;
+			}
+
+			/* Check consonants */
+			if (strchr("bcdfghjklmnpqrstvwxz", c))
+			{
+				consonants++;
+			}
+			else
+			{
+				if (consonants > highest_consonants)
+					highest_consonants = consonants;
+				consonants = 0;
+			}
+
+			/* Check vowels */
+			if (strchr("aeiou", c))
+			{
+				vowels++;
+			}
+			else
+			{
+				if (vowels > highest_vowels)
+					highest_vowels = vowels;
+				vowels = 0;
+			}
+		}
+
+		/* Now set up for our checks. */
+		if (highest_digits > digits)
+			digits = highest_digits;
+		if (highest_consonants > consonants)
+			consonants = highest_consonants;
+		if (highest_vowels > vowels)
+			vowels = highest_vowels;
+
+		if (digits >= 5)
+		{
+			score += digits;
+			if (this->DebugMode)
+				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: %s:MATCH digits", original_str.c_str());
+		}
+		if (vowels >= 4)
+		{
+			score += vowels;
+			if (this->DebugMode)
+				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: %s:MATCH vowels", original_str.c_str());
+		}
+		if (consonants >= 4)
+		{
+			score += consonants;
+			if (this->DebugMode)
+				ServerInstance->SNO.WriteGlobalSno('a',  "m_antirandom: %s:MATCH consonants", original_str.c_str());
+		}
+
+
+		/*
+		 * Now, do the triples checks. For each char in the string we're checking ...
+		 */
+		if (original_str.length() >= 3) // Make sure the string is at least 3 characters long
+		{
+			for (size_t i = 0; i < (original_str.length() - 2); i++)
+			{
+				std::map<std::string, std::string>::const_iterator trip = triples_map.find(original_str.substr(i, 2));
+				// Check whether the current and next characters are the first half of a triple, if so, check for the 3rd character in the second half
+				if (trip != triples_map.end() && trip->second.find_first_of(original_str[i + 2]) != std::string::npos)
+				{
+					score++;
+					if (this->DebugMode)
+						ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: %s:MATCH triple (%s:%c/%c/%c)",
+															original_str.c_str(), trip->second.c_str(), original_str[i], original_str[i + 1], original_str[i + 2]);
+				}
+			}
+		}
+		return score;
+	}
+
+	unsigned int GetUserScore(User *user)
+	{
+		int nscore, uscore, gscore, score;
+		struct timeval tv_alpha, tv_beta;
+
+		gettimeofday(&tv_alpha, NULL);
+
+		nscore = GetStringScore(user->nick);
+		uscore = GetStringScore(user->GetRealUser());
+		gscore = GetStringScore(user->GetRealName());
+		score = nscore + uscore + gscore;
+
+		gettimeofday(&tv_beta, NULL);
+		if (this->DebugMode)
+			ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom Timing: %ld microseconds",
+				((tv_beta.tv_sec - tv_alpha.tv_sec) * 1000000) + (tv_beta.tv_usec - tv_alpha.tv_usec));
+
+		if (this->DebugMode)
+			ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom Got score: %d/%d/%d = %d", nscore, uscore, gscore, score);
+		return score;
+	}
+
+	bool IsAntirandomExempt(User *user)
+	{
+		for (AntirandomExemptList::iterator iter = Exempts.begin(); iter != Exempts.end(); iter++)
+		{
+			switch (iter->type)
+			{
+				case NICK:
+				{
+					if (InspIRCd::Match(user->nick, iter->pattern, ascii_case_insensitive_map))
+					{
+						if (this->DebugMode)
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: NICK (%s)", iter->pattern.c_str());
+						return true;
+					}
+					break;
+				}
+				case REALUSER:
+				{
+					if (InspIRCd::Match(user->GetRealUser(), iter->pattern, ascii_case_insensitive_map))
+					{
+						if (this->DebugMode)
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: REALUSER (%s)", iter->pattern.c_str());
+						return true;
+					}
+					break;
+				}
+				case HOST:
+				{
+					if (InspIRCd::Match(user->GetRealHost(), iter->pattern, ascii_case_insensitive_map) || InspIRCd::MatchCIDR(user->GetAddress().c_str(), iter->pattern, ascii_case_insensitive_map))
+					{
+						if (this->DebugMode)
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: HOST (%s)", iter->pattern.c_str());
+						return true;
+					}
+					break;
+				}
+				case FULLNAME:
+				{
+					if (InspIRCd::Match(user->GetRealName(), iter->pattern, ascii_case_insensitive_map))
+					{
+						if (this->DebugMode)
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: FULLNAME (%s)", iter->pattern.c_str());
+						return true;
+					}
+					break;
+				}
+			}
+		}
+		return false;
+	}
+
+	ModResult OnUserRegister(LocalUser* user)
+	{
+		if (IsAntirandomExempt(user))
+		{
+			return MOD_RES_PASSTHRU;
+		}
+
+		unsigned int score = GetUserScore(user);
+
+		if (score > this->Threshold)
+		{
+			std::string method = "allowed because no action was set";
+
+			switch (this->BanAction)
+			{
+				case ANTIRANDOM_ACT_KILL:
+				{
+					ServerInstance->Users.QuitUser(user, this->BanReason);
+					method="Killed";
+					break;
+				}
+				case ANTIRANDOM_ACT_ZLINE:
+				{
+					ZLine* zl = new ZLine(ServerInstance->Time(), this->BanDuration, ServerInstance->Config->ServerName, this->BanReason.c_str(), user->GetAddress().c_str());
+					if (ServerInstance->XLines->AddLine(zl,user))
+						ServerInstance->XLines->ApplyLines();
+					else
+						delete zl;
+					method="Z-Lined";
+					break;
+				}
+				case ANTIRANDOM_ACT_GLINE:
+				{
+					GLine* gl = new GLine(ServerInstance->Time(), this->BanDuration, ServerInstance->Config->ServerName, this->BanReason.c_str(), "*", user->GetAddress().c_str());
+					if (ServerInstance->XLines->AddLine(gl,user))
+						ServerInstance->XLines->ApplyLines();
+					else
+						delete gl;
+					method="G-Lined";
+					break;
+				}
+			}
+			if (this->ShowFailedConnects)
+			{
+				std::string realhost = user->GetRealMask();
+				ServerInstance->SNO.WriteGlobalSno('a', "Connection from %s (%s) was %s by m_antirandom with a score of %d - which exceeds threshold of %d", realhost.c_str(), user->GetAddress().c_str(), method.c_str(), score, this->Threshold);
+
+				ServerInstance->Logs.Normal(MODNAME, "Connection from %s (%s) was %s by m_antirandom with a score of %d - which exceeds threshold of %d", realhost.c_str(), user->GetAddress().c_str(), method.c_str(), score, this->Threshold);
+			}
+			return MOD_RES_DENY;
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void ReadConfig(ConfigStatus& status)
+	{
+		ConfigTag* conftag = ServerInstance->Config->ConfValue("antirandom").get();
+
+		this->ShowFailedConnects = conftag->getBool("showfailedconnects", true);
+		this->DebugMode = conftag->getBool("debugmode");
+		this->Threshold = conftag->getNum("threshold", 10, 1, 100);
+
+		this->BanAction = ANTIRANDOM_ACT_NONE;
+		std::string tmp = conftag->getString("banaction");
+		if (tmp == "GLINE")
+		{
+			this->BanAction = ANTIRANDOM_ACT_GLINE;
+		}
+		if (tmp == "ZLINE")
+		{
+			this->BanAction = ANTIRANDOM_ACT_ZLINE;
+		}
+		else if (tmp == "KILL")
+		{
+			this->BanAction = ANTIRANDOM_ACT_KILL;
+		}
+
+		this->BanDuration = conftag->getDuration("banduration", 86400, 1);
+		this->BanReason = conftag->getString("banreason", "You look like a bot. Change your nick/ident/gecos and try reconnecting.", 1);
+
+		Exempts.clear();
+
+		for (const auto& [_, tag] : ServerInstance->Config->ConfTags("antirandomexempt"))
+		{
+			std::string type = tag->getString("type");
+			std::string pattern = tag->getString("pattern");
+
+			if(pattern.length() && type.length())
+			{
+				AntirandomExemptType exemptType;
+				if (type == "nick")
+					exemptType = NICK;
+				else if (type == "realuser")
+					exemptType = REALUSER;
+				else if (type == "host")
+					exemptType = HOST;
+				else if (type == "fullname")
+					exemptType = FULLNAME;
+				else
+				{
+					ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Invalid <antirandomexempt:type> value in config: %s", type.c_str());
+					ServerInstance->Logs.Normal(MODNAME, "m_antirandom: Invalid <antirandomexempt:type> value in config: %s", type.c_str());
+					continue;
+				}
+
+				Exempts.push_back(AntirandomExempt(exemptType, pattern));
+				if (this->DebugMode)
+					ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Added exempt: %s (%s)", type.c_str(), pattern.c_str());
+			}
+			else
+			{
+				ServerInstance->Logs.Normal(MODNAME, "m_antirandom: Invalid block <antirandomexempt type=\"%s\" pattern=\"%s\">", type.c_str(), pattern.c_str());
+				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Invalid block <antirandomexempt type=\"%s\" pattern=\"%s\">", type.c_str(), pattern.c_str());
+				continue;
+			}
+		}
+	}
+
+};
+
+
+MODULE_INIT(ModuleAntiRandom)
+

--- a/4/m_antirandom.cpp
+++ b/4/m_antirandom.cpp
@@ -609,19 +609,19 @@ class ModuleAntiRandom : public Module
 		{
 			score += digits;
 			if (this->DebugMode)
-				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: %s:MATCH digits", original_str.c_str());
+				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: {}:MATCH digits", original_str);
 		}
 		if (vowels >= 4)
 		{
 			score += vowels;
 			if (this->DebugMode)
-				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: %s:MATCH vowels", original_str.c_str());
+				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: {}:MATCH vowels", original_str);
 		}
 		if (consonants >= 4)
 		{
 			score += consonants;
 			if (this->DebugMode)
-				ServerInstance->SNO.WriteGlobalSno('a',  "m_antirandom: %s:MATCH consonants", original_str.c_str());
+				ServerInstance->SNO.WriteGlobalSno('a',  "m_antirandom: {}:MATCH consonants", original_str);
 		}
 
 
@@ -638,8 +638,8 @@ class ModuleAntiRandom : public Module
 				{
 					score++;
 					if (this->DebugMode)
-						ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: %s:MATCH triple (%s:%c/%c/%c)",
-															original_str.c_str(), trip->second.c_str(), original_str[i], original_str[i + 1], original_str[i + 2]);
+						ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: {}:MATCH triple ({}:{}/{}/{})",
+															original_str, trip->second, original_str[i], original_str[i + 1], original_str[i + 2]);
 				}
 			}
 		}
@@ -660,11 +660,11 @@ class ModuleAntiRandom : public Module
 
 		gettimeofday(&tv_beta, NULL);
 		if (this->DebugMode)
-			ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom Timing: %ld microseconds",
+			ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom Timing: {} microseconds",
 				((tv_beta.tv_sec - tv_alpha.tv_sec) * 1000000) + (tv_beta.tv_usec - tv_alpha.tv_usec));
 
 		if (this->DebugMode)
-			ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom Got score: %d/%d/%d = %d", nscore, uscore, gscore, score);
+			ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom Got score: {}/{}/{} = {}", nscore, uscore, gscore, score);
 		return score;
 	}
 
@@ -679,7 +679,7 @@ class ModuleAntiRandom : public Module
 					if (InspIRCd::Match(user->nick, iter->pattern, ascii_case_insensitive_map))
 					{
 						if (this->DebugMode)
-							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: NICK (%s)", iter->pattern.c_str());
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: NICK ({})", iter->pattern);
 						return true;
 					}
 					break;
@@ -689,7 +689,7 @@ class ModuleAntiRandom : public Module
 					if (InspIRCd::Match(user->GetRealUser(), iter->pattern, ascii_case_insensitive_map))
 					{
 						if (this->DebugMode)
-							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: REALUSER (%s)", iter->pattern.c_str());
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: REALUSER ({})", iter->pattern);
 						return true;
 					}
 					break;
@@ -699,7 +699,7 @@ class ModuleAntiRandom : public Module
 					if (InspIRCd::Match(user->GetRealHost(), iter->pattern, ascii_case_insensitive_map) || InspIRCd::MatchCIDR(user->GetAddress().c_str(), iter->pattern, ascii_case_insensitive_map))
 					{
 						if (this->DebugMode)
-							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: HOST (%s)", iter->pattern.c_str());
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: HOST ({})", iter->pattern);
 						return true;
 					}
 					break;
@@ -709,7 +709,7 @@ class ModuleAntiRandom : public Module
 					if (InspIRCd::Match(user->GetRealName(), iter->pattern, ascii_case_insensitive_map))
 					{
 						if (this->DebugMode)
-							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: FULLNAME (%s)", iter->pattern.c_str());
+							ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom exempt: FULLNAME ({})", iter->pattern);
 						return true;
 					}
 					break;
@@ -764,9 +764,9 @@ class ModuleAntiRandom : public Module
 			if (this->ShowFailedConnects)
 			{
 				std::string realhost = user->GetRealMask();
-				ServerInstance->SNO.WriteGlobalSno('a', "Connection from %s (%s) was %s by m_antirandom with a score of %d - which exceeds threshold of %d", realhost.c_str(), user->GetAddress().c_str(), method.c_str(), score, this->Threshold);
+				ServerInstance->SNO.WriteGlobalSno('a', "Connection from {} ({}) was {} by m_antirandom with a score of {} - which exceeds threshold of {}", realhost, user->GetAddress(), method, score, this->Threshold);
 
-				ServerInstance->Logs.Normal(MODNAME, "Connection from %s (%s) was %s by m_antirandom with a score of %d - which exceeds threshold of %d", realhost.c_str(), user->GetAddress().c_str(), method.c_str(), score, this->Threshold);
+				ServerInstance->Logs.Normal(MODNAME, "Connection from {} ({}) was {} by m_antirandom with a score of {} - which exceeds threshold of {}", realhost, user->GetAddress(), method, score, this->Threshold);
 			}
 			return MOD_RES_DENY;
 		}
@@ -819,19 +819,19 @@ class ModuleAntiRandom : public Module
 					exemptType = FULLNAME;
 				else
 				{
-					ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Invalid <antirandomexempt:type> value in config: %s", type.c_str());
-					ServerInstance->Logs.Normal(MODNAME, "m_antirandom: Invalid <antirandomexempt:type> value in config: %s", type.c_str());
+					ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Invalid <antirandomexempt:type> value in config: {}", type);
+					ServerInstance->Logs.Normal(MODNAME, "m_antirandom: Invalid <antirandomexempt:type> value in config: {}", type);
 					continue;
 				}
 
 				Exempts.push_back(AntirandomExempt(exemptType, pattern));
 				if (this->DebugMode)
-					ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Added exempt: %s (%s)", type.c_str(), pattern.c_str());
+					ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Added exempt: {} ({})", type, pattern);
 			}
 			else
 			{
-				ServerInstance->Logs.Normal(MODNAME, "m_antirandom: Invalid block <antirandomexempt type=\"%s\" pattern=\"%s\">", type.c_str(), pattern.c_str());
-				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Invalid block <antirandomexempt type=\"%s\" pattern=\"%s\">", type.c_str(), pattern.c_str());
+				ServerInstance->Logs.Normal(MODNAME, "m_antirandom: Invalid block <antirandomexempt type=\"{}\" pattern=\"{}\">", type, pattern);
+				ServerInstance->SNO.WriteGlobalSno('a', "m_antirandom: Invalid block <antirandomexempt type=\"{}\" pattern=\"{}\">", type, pattern);
 				continue;
 			}
 		}

--- a/4/m_antirandom.cpp
+++ b/4/m_antirandom.cpp
@@ -51,8 +51,7 @@
 #include "xline.h"
 
 /// $ModDesc: A module to prevent against bots using random patterns.
-/// $ModAuthor: lnx85
-/// $ModAuthorMail: lnx85@lnxlabs.it
+/// $ModAuthor: lnx85 <lnx85@lnxlabs.it>
 /// $ModDepends: core 4
 
 #define ANTIRANDOM_ACT_KILL     0

--- a/4/m_antirandom.cpp
+++ b/4/m_antirandom.cpp
@@ -774,7 +774,7 @@ class ModuleAntiRandom : public Module
 
 	void ReadConfig(ConfigStatus& status)
 	{
-		ConfigTag* conftag = ServerInstance->Config->ConfValue("antirandom").get();
+		const auto& conftag = ServerInstance->Config->ConfValue("antirandom");
 
 		this->ShowFailedConnects = conftag->getBool("showfailedconnects", true);
 		this->DebugMode = conftag->getBool("debugmode");

--- a/4/m_antirandom.cpp
+++ b/4/m_antirandom.cpp
@@ -536,7 +536,7 @@ class ModuleAntiRandom : public Module
 	bool DebugMode;
 	unsigned int Threshold;
 	unsigned int BanAction;
-	unsigned int BanDuration;
+	unsigned long BanDuration;
 	std::string BanReason;
 	AntirandomExemptList Exempts;
  public:

--- a/4/m_close.cpp
+++ b/4/m_close.cpp
@@ -1,0 +1,82 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2007 Carsten Valdemar Munk <carsten.munk+inspircd@gmail.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: InspIRCd Developers
+/// $ModAuthorMail: noreply@inspircd.org
+/// $ModDepends: core 4
+/// $ModDesc: Provides the ability to close unregistered connections.
+
+
+#include "inspircd.h"
+
+class CommandClose : public Command
+{
+ public:
+	CommandClose(Module* Creator)
+		: Command(Creator,"CLOSE")
+	{
+		access_needed = CmdAccess::OPERATOR;
+	}
+
+	CmdResult Handle(User* src, const Params& parameters) override
+	{
+		std::map<std::string,int> closed;
+
+		const UserManager::LocalList& list = ServerInstance->Users.GetLocalUsers();
+		for (UserManager::LocalList::const_iterator u = list.begin(); u != list.end(); )
+		{
+			// Quitting the user removes it from the list
+			LocalUser* user = *u;
+			++u;
+			if (!user->IsFullyConnected())
+			{
+				ServerInstance->Users.QuitUser(user, "Closing all unknown connections per request");
+				std::string key = ConvToStr(user->GetAddress())+"."+ConvToStr(user->server_sa.port());
+				closed[key]++;
+			}
+		}
+
+		int total = 0;
+		for (std::map<std::string,int>::iterator ci = closed.begin(); ci != closed.end(); ci++)
+		{
+			src->WriteNotice("*** Closed " + ConvToStr(ci->second) + " unknown " + (ci->second == 1 ? "connection" : "connections") +
+				" from [" + ci->first + "]");
+			total += ci->second;
+		}
+		if (total)
+			src->WriteNotice("*** " + ConvToStr(total) + " unknown " + (total == 1 ? "connection" : "connections") + " closed");
+		else
+			src->WriteNotice("*** No unknown connections found");
+
+		return CmdResult::SUCCESS;
+	}
+};
+
+class ModuleClose : public Module
+{
+	CommandClose cmd;
+ public:
+	ModuleClose() : Module(VF_NONE, "Provides the ability to close unregistered connections."),
+		cmd(this)
+	{
+	}
+};
+
+MODULE_INIT(ModuleClose)

--- a/4/m_close.cpp
+++ b/4/m_close.cpp
@@ -18,8 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// $ModAuthor: InspIRCd Developers
-/// $ModAuthorMail: noreply@inspircd.org
+/// $ModAuthor: TheUnstoppable <theunstoppable1000@gmail.com>
 /// $ModDepends: core 4
 /// $ModDesc: Provides the ability to close unregistered connections.
 

--- a/4/m_conn_matchgecos.cpp
+++ b/4/m_conn_matchgecos.cpp
@@ -30,7 +30,7 @@ public:
 
     ModResult OnPreChangeConnectClass(LocalUser* user, const std::shared_ptr<ConnectClass>& klass, std::optional<Numeric::Numeric>& errnum) override
     {
-        auto connClass = klass.get();
+        const auto& connClass = klass;
 
         std::string matches;
         if (!connClass->config->readString("matchgecos", matches, true))

--- a/4/m_conn_matchgecos.cpp
+++ b/4/m_conn_matchgecos.cpp
@@ -1,5 +1,5 @@
 /*
-* InspIRCd -- Internet Relay Chat Daemon
+ * InspIRCd -- Internet Relay Chat Daemon
  *
  *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
  *
@@ -54,7 +54,7 @@ public:
                 return MOD_RES_PASSTHRU;
             }
         }
-        
+
         return MOD_RES_DENY;
     }
 };

--- a/4/m_conn_matchgecos.cpp
+++ b/4/m_conn_matchgecos.cpp
@@ -1,0 +1,62 @@
+/*
+* InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: TheUnstoppable
+/// $ModAuthorMail: theunstoppable1000@gmail.com
+/// $ModConfig: <connect matchgecos="John Doe\nJane Doe"> # Separate values with new line
+/// $ModDepends: core 4
+/// $ModDesc: Allows a connect class to match by real name(s)/gecos.
+
+#include "inspircd.h"
+
+class ModuleConnMatchGecos : public Module {
+public:
+    ModuleConnMatchGecos() : Module(VF_NONE, "Allows a connect class to match by real name(s)/gecos.") {}
+
+    ModResult OnPreChangeConnectClass(LocalUser* user, const std::shared_ptr<ConnectClass>& klass, std::optional<Numeric::Numeric>& errnum) override
+    {
+        auto connClass = klass.get();
+
+        std::string matches;
+        if (!connClass->config->readString("matchgecos", matches, true))
+        {
+            return MOD_RES_PASSTHRU;
+        }
+
+        std::istringstream ss(matches);
+        while (!ss.eof())
+        {
+            std::string line;
+            std::getline(ss, line);
+
+            if (line.empty())
+            {
+                continue;
+            }
+
+            if (InspIRCd::Match(line, user->GetRealName()))
+            {
+                return MOD_RES_PASSTHRU;
+            }
+        }
+        
+        return MOD_RES_DENY;
+    }
+};
+
+MODULE_INIT(ModuleConnMatchGecos)

--- a/4/m_conn_matchgecos.cpp
+++ b/4/m_conn_matchgecos.cpp
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// $ModAuthor: TheUnstoppable
-/// $ModAuthorMail: theunstoppable1000@gmail.com
+/// $ModAuthor: TheUnstoppable <theunstoppable1000@gmail.com>
 /// $ModConfig: <connect matchgecos="John Doe\nJane Doe"> # Separate values with new line
 /// $ModDepends: core 4
 /// $ModDesc: Allows a connect class to match by real name(s)/gecos.

--- a/4/m_conn_matchident.cpp
+++ b/4/m_conn_matchident.cpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// $ModAuthor: genius3000
-/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModAuthor: genius3000 <genius3000@g3k.solutions>
 /// $ModConfig: <connect matchident="myIdent thatIdent ~thisIdent">
 /// $ModDepends: core 4
 /// $ModDesc: Allows a connect class to match by ident(s).

--- a/4/m_conn_matchident.cpp
+++ b/4/m_conn_matchident.cpp
@@ -42,7 +42,7 @@ class ModuleConnMatchIdent : public Module
 
 	ModResult OnPreChangeConnectClass(LocalUser* user, const std::shared_ptr<ConnectClass>& klass, std::optional<Numeric::Numeric>& errnum) override
 	{
-		auto connclass = klass.get();
+		const auto& connclass = klass;
 
 		const std::string matchident = connclass->config->getString("matchident");
 		if (matchident.empty())

--- a/4/m_conn_matchident.cpp
+++ b/4/m_conn_matchident.cpp
@@ -1,0 +1,62 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *   Copyright (C) 2017-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <connect matchident="myIdent thatIdent ~thisIdent">
+/// $ModDepends: core 4
+/// $ModDesc: Allows a connect class to match by ident(s).
+
+
+#include "inspircd.h"
+
+class ModuleConnMatchIdent : public Module
+{
+ public:
+	ModuleConnMatchIdent() : Module(VF_NONE, "Allows a connect class to match by ident(s).")
+	{
+	}
+
+	void Prioritize() override
+	{
+		// Go after requireident, which is recommended but not required.
+		Module* requireident = ServerInstance->Modules.Find("m_ident.so");
+		ServerInstance->Modules.SetPriority(this, I_OnPreChangeConnectClass, PRIORITY_AFTER, requireident);
+	}
+
+	ModResult OnPreChangeConnectClass(LocalUser* user, const std::shared_ptr<ConnectClass>& klass, std::optional<Numeric::Numeric>& errnum) override
+	{
+		auto connclass = klass.get();
+
+		const std::string matchident = connclass->config->getString("matchident");
+		if (matchident.empty())
+			return MOD_RES_PASSTHRU;
+
+		irc::spacesepstream ss(matchident);
+		for (std::string token; ss.GetToken(token); )
+		{
+			if (InspIRCd::Match(user->GetRealUser(), token))
+				return MOD_RES_PASSTHRU;
+		}
+
+		return MOD_RES_DENY;
+	}
+};
+
+MODULE_INIT(ModuleConnMatchIdent)

--- a/4/m_conn_require.cpp
+++ b/4/m_conn_require.cpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// $ModAuthor: genius3000
-/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModAuthor: genius3000 <genius3000@g3k.solutions>
 /// $ModConfig: <connrequire timeout="5" ctcpstring="TIME" blockmessage="Your client isn't up to spec!">
 /// $ModDepends: core 4
 /// $ModDesc: Allow or block connections based on multiple criteria

--- a/4/m_conn_require.cpp
+++ b/4/m_conn_require.cpp
@@ -217,19 +217,19 @@ class ModuleConnRequire : public Module
 
 	void ReadConfig(ConfigStatus&) override
 	{
-		ConfigTag* tag = ServerInstance->Config->ConfValue("connrequire").get();
-		timeout = tag->getNum("timeout", 5, 1, 30);
-		disableversion = tag->getBool("disableversion");
-		ctcpstring = tag->getString("ctcpstring");
-		blockmessage = tag->getString("blockmessage");
+		const auto& reqtag = ServerInstance->Config->ConfValue("connrequire");
+		timeout = reqtag->getNum("timeout", 5, 1, 30);
+		disableversion = reqtag->getBool("disableversion");
+		ctcpstring = reqtag->getString("ctcpstring");
+		blockmessage = reqtag->getString("blockmessage");
 		std::transform(ctcpstring.begin(), ctcpstring.end(), ctcpstring.begin(), ::toupper);
 
-		tag = ServerInstance->Config->ConfValue("dualversion").get();
-		dualversion = tag->getBool("active");
-		dualshow = tag->getBool("showdual");
-		dualban = tag->getBool("ban");
-		dualduration = tag->getDuration("duration", 60*60*24*7);
-		dualreason = tag->getString("reason", "Fix your client!");
+		const auto& dualtag = ServerInstance->Config->ConfValue("dualversion");
+		dualversion = dualtag->getBool("active");
+		dualshow = dualtag->getBool("showdual");
+		dualban = dualtag->getBool("ban");
+		dualduration = dualtag->getDuration("duration", 60*60*24*7);
+		dualreason = dualtag->getString("reason", "Fix your client!");
 
 		// No need to send VERSION here, it's already taken care of
 		if (!strcmp(ctcpstring.c_str(), "VERSION"))
@@ -406,7 +406,7 @@ class ModuleConnRequire : public Module
 
 	ModResult OnPreChangeConnectClass(LocalUser* user, const std::shared_ptr<ConnectClass>& klass, std::optional<Numeric::Numeric>& errnum) override
 	{
-		auto cc = klass.get();
+		const auto& cc = klass;
 
 		// Don't mess with the initial class setting
 		// This way we only act after the client has had time to send CAP or CTCP replies

--- a/4/m_conn_require.cpp
+++ b/4/m_conn_require.cpp
@@ -158,8 +158,8 @@ class ModuleConnRequire : public Module
 		const std::string& source = ServerInstance->Config->ServerName;
 		const std::string timetype = (duration == 0 ? "permanent" : "timed");
 		const std::string expires = (duration == 0 ? "" : INSP_FORMAT(", expires in {} (on {})",
-			Duration::ToString(duration).c_str(),
-			Time::ToString(ServerInstance->Time() + duration).c_str()));
+			Duration::ToString(duration),
+			Time::ToString(ServerInstance->Time() + duration)));
 
 		std::string dueto;
 		if (from == "dual")
@@ -172,8 +172,8 @@ class ModuleConnRequire : public Module
 		XLine* x = xlf->Generate(ServerInstance->Time(), duration, source, reason, mask);
 		if (ServerInstance->XLines->AddLine(x, NULL))
 		{
-			ServerInstance->SNO.WriteToSnoMask('x', "%s added %s Z-line for %s%s due to %s: %s", source.c_str(),
-				timetype.c_str(), mask.c_str(), expires.c_str(), dueto.c_str(), reason.c_str());
+			ServerInstance->SNO.WriteToSnoMask('x', "{} added {} Z-line for {}{} due to {}: {}", source,
+				timetype, mask, expires, dueto, reason);
 		}
 		else
 			delete x;
@@ -340,8 +340,8 @@ class ModuleConnRequire : public Module
 				if (bv.ban)
 					SetZLine(user, bv.duration, bv.reason, "badversion");
 
-				ServerInstance->SNO.WriteToSnoMask('u', "Blocked user %s (%s) [%s] on port %d, version reply \"%s\" matched badversion mask \"%s\"",
-					user->GetRealMask().c_str(), user->GetAddress().c_str(), user->GetRealName().c_str(), user->server_sa.port(), rplversion.c_str(), bv.mask.c_str());
+				ServerInstance->SNO.WriteToSnoMask('u', "Blocked user {} ({}) [{}] on port {}, version reply \"{}\" matched badversion mask \"{}\"",
+					user->GetRealMask(), user->GetAddress(), user->GetRealName(), user->server_sa.port(), rplversion, bv.mask);
 				ud->zapped = true;
 				ServerInstance->Users.QuitUser(user, bv.reason);
 
@@ -369,11 +369,11 @@ class ModuleConnRequire : public Module
 				if (dualban)
 					SetZLine(user, dualduration, dualreason, "dual");
 
-				ServerInstance->SNO.WriteToSnoMask('u', "Blocked user %s (%s) [%s] from connecting on port %d for mismatched version replies",
-					user->GetRealMask().c_str(), user->GetAddress().c_str(), user->GetRealName().c_str(), user->server_sa.port());
+				ServerInstance->SNO.WriteToSnoMask('u', "Blocked user {} ({}) [{}] from connecting on port {} for mismatched version replies",
+					user->GetRealMask(), user->GetAddress(), user->GetRealName(), user->server_sa.port());
 
 				if (dualshow)
-					ServerInstance->SNO.WriteToSnoMask('u', "Version replies \"%s\" and \"%s\"", firstversionreply.c_str(), secondversionreply.c_str());
+					ServerInstance->SNO.WriteToSnoMask('u', "Version replies \"{}\" and \"{}\"", firstversionreply, secondversionreply);
 
 				ud->zapped = true;
 				ServerInstance->Users.QuitUser(user, dualreason);
@@ -479,8 +479,8 @@ class ModuleConnRequire : public Module
 		// We didn't block any connect classes for this user.
 		if (!ud->ccblocked)
 		{
-			ServerInstance->Logs.Debug(MODNAME, "Unregistered user exiting for unknown reasons: %s (%s) [%s]",
-				user->GetRealMask().c_str(), user->GetAddress().c_str(), user->GetRealName().c_str());
+			ServerInstance->Logs.Debug(MODNAME, "Unregistered user exiting for unknown reasons: {} ({}) [{}]",
+				user->GetRealMask(), user->GetAddress(), user->GetRealName());
 			return;
 		}
 

--- a/4/m_conn_require.cpp
+++ b/4/m_conn_require.cpp
@@ -1,0 +1,530 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2020 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <connrequire timeout="5" ctcpstring="TIME" blockmessage="Your client isn't up to spec!">
+/// $ModDepends: core 3
+/// $ModDesc: Allow or block connections based on multiple criteria
+
+/* More available config tags:
+ * <dualversion active="yes" show="yes" ban="yes" duration="7d" reason="Fix your client!">
+ * <badversion mask="*terrible script*" reason="Your script is terrible, bye bye!">
+ * <badversion mask="xchat*" ban="yes" duration="7d" reason="Time to upgrade to Hexchat!">
+ * <banmissing cap="yes" version="yes" duration="14d" reason="Upgrade your client!">
+ * <banmissing ctcp="yes" duration="1d" reason="Don't ignore me!">
+ *
+ * Descriptions and defaults:
+ * <connrequire >
+ * timeout:        max number of seconds to hold a user while waiting for replies. Default: 5
+ * ctcpstring:     a secondary CTCP request, aside from "VERSION". Default: blank
+ * blockmessage:   a message sent to the user upon disconnect if we likely caused it. Default: blank
+ * disableversion: disable the CTCP "VERSION" request (leaves just CAP and ctcpstring useful). Default: no
+ * <dualversion >
+ * active:         controls the second "VERSION" request that blocks on mismatch. Default: no
+ * show:           send a SNOTICE of the two replies when they don't match. Default: no
+ * ban:            Z-Line the IP on a mismatch. Default: no
+ * duration:       time string for the Z-Line duration. Default: 7d
+ * reason:         used for both the block and Z-Line. Default: Fix your client!
+ * <badversion >
+ * mask:           wildcard mask to block/ban of an unwanted client version. Default: blank
+ * ban:            Z-Line the IP on a match. Default: no
+ * duration:       time string for the Z-Line duration. Default: 7d
+ * reason:         used for both the block and Z-Line. Default: Upgrade your client!
+ * <banmissing >
+ * cap:            whether a lack of CAP matches this tag. Default: no
+ * ctcp:           whether a lack of secondary CTCP (if enabled) reply matches this tag. Default: no
+ * version:        whether a lack of VERSION reply matches this tag. Default: no
+ * duration:       time string for the Z-Line duration. Default: 1d
+ * reason:         used for the Z-Line. Default: Fix your client!
+ *
+ * <badversion> and <banmissing> tags will be matched in the same order as they appear
+ * in the config.
+ *
+ * Connect class options:
+ * requirecap:		require the client to have requested CAP.
+ * requirectcp:		requre the client to have replied to the secondary CTCP request.
+ * requireversion:	require the client to have replied to the VERSION request.
+ * All three default to "no".
+ *
+ * The intent here is to harden your "open" connect classes with these options to
+ * deny them a connection. If you wish to Z-Line for certain reasons, use a
+ * <banmissing> tag. The dual version check acts on it's own.
+ * You can also use the <banversion> tags as freely as you wish.
+ *
+ * SNOTICES regarding blocked user connections are sent to SNOMASK 'u'
+ */
+
+/* NOTE: This module is not a direct replacement for m_requirectcp but is a
+ * complete rework of the original idea. They cannot be loaded at the same time.
+ */
+
+
+#include "inspircd.h"
+#include "extension.h"
+#include "timeutils.h"
+#include "clientprotocolmsg.h"
+#include "xline.h"
+
+// ExtItem per User, tracking CAP request and CTCP replies
+struct UserData
+{
+	bool ccblocked;
+	bool ctcpreply;
+	bool expectctcp;
+	bool expectversion;
+	bool selfquit;
+	bool sentcap;
+	bool zapped;
+	std::string firstversionreply;
+	std::string secondversionreply;
+
+	UserData()
+		: ccblocked(false)
+		, ctcpreply(false)
+		, expectctcp(false)
+		, expectversion(false)
+		, selfquit(false)
+		, sentcap(false)
+		, zapped(false)
+	{
+	}
+};
+
+// Data from one <badversion> tag
+struct BadVersion
+{
+	bool ban;
+	time_t duration;
+	std::string mask;
+	std::string reason;
+};
+
+// Data from one <banmising> tag
+struct BanMissing
+{
+	bool cap;
+	bool ctcp;
+	bool version;
+	time_t duration;
+	std::string reason;
+};
+
+class ModuleConnRequire : public Module
+{
+	SimpleExtItem<UserData> userdata;
+
+	std::vector<BadVersion> badversions;
+	std::vector<BanMissing> banmissings;
+
+	bool dualversion;
+	bool dualshow;
+	bool dualban;
+	time_t dualduration;
+	std::string dualreason;
+
+	const char wrapper;
+	const std::string ctcpversion;
+	const std::string::size_type len_part;
+	const std::string::size_type len_all;
+	bool disableversion;
+	std::string ctcpstring;
+	std::string blockmessage;
+	time_t timeout;
+
+	void SetZLine(User* user, time_t duration, const std::string& reason, const std::string& from)
+	{
+		XLineFactory* xlf = ServerInstance->XLines->GetFactory("Z");
+		if (!xlf)
+			return;
+
+		const std::string& mask = user->GetAddress();
+		const std::string& source = ServerInstance->Config->ServerName;
+		const std::string timetype = (duration == 0 ? "permanent" : "timed");
+		const std::string expires = (duration == 0 ? "" : INSP_FORMAT(", expires in {} (on {})",
+			Duration::ToString(duration).c_str(),
+			Time::ToString(ServerInstance->Time() + duration).c_str()));
+
+		std::string dueto;
+		if (from == "dual")
+			dueto = "a version reply mismatch";
+		else if (from == "badversion")
+			dueto = "a match to a bad version";
+		else if (from == "banmissing")
+			dueto = "a match to a ban on missing data";
+
+		XLine* x = xlf->Generate(ServerInstance->Time(), duration, source, reason, mask);
+		if (ServerInstance->XLines->AddLine(x, NULL))
+		{
+			ServerInstance->SNO.WriteToSnoMask('x', "%s added %s Z-line for %s%s due to %s: %s", source.c_str(),
+				timetype.c_str(), mask.c_str(), expires.c_str(), dueto.c_str(), reason.c_str());
+		}
+		else
+			delete x;
+	}
+
+ public:
+	ModuleConnRequire ()
+		: Module(VF_NONE, "Allow or block connections based on multiple criteria")
+		, userdata(this, "userdata", ExtensionType::USER)
+		, wrapper('\001')
+		, ctcpversion("VERSION")
+		, len_part(ctcpversion.length() + 2)
+		, len_all(len_part + 1)
+	{
+	}
+
+	void init() override
+	{
+		if (ServerInstance->Modules.Find("m_requirectcp.so") != NULL)
+			throw ModuleException(this, "You have m_requirectcp loaded! This module will not work correctly alongside that.");
+
+		ServerInstance->SNO.EnableSnomask('u', "CONN_REQUIRE");
+	}
+
+	void Prioritize() override
+	{
+		// Send the CTCP requests ASAP.
+		ServerInstance->Modules.SetPriority(this, I_OnChangeRemoteAddress, PRIORITY_FIRST);
+	}
+
+	void OnLoadModule(Module* mod) override
+	{
+		// m_requirectcp will cause undesirable results
+		if (mod->ModuleFile != "m_requirectcp.so")
+			return;
+
+		const std::string message = "Warning: m_conn_require will not work correctly alongside m_requirectcp.";
+		ServerInstance->SNO.WriteToSnoMask('a', message);
+		throw ModuleException(this, message);
+	}
+
+	void ReadConfig(ConfigStatus&) override
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("connrequire").get();
+		timeout = tag->getNum("timeout", 5, 1, 30);
+		disableversion = tag->getBool("disableversion");
+		ctcpstring = tag->getString("ctcpstring");
+		blockmessage = tag->getString("blockmessage");
+		std::transform(ctcpstring.begin(), ctcpstring.end(), ctcpstring.begin(), ::toupper);
+
+		tag = ServerInstance->Config->ConfValue("dualversion").get();
+		dualversion = tag->getBool("active");
+		dualshow = tag->getBool("showdual");
+		dualban = tag->getBool("ban");
+		dualduration = tag->getDuration("duration", 60*60*24*7);
+		dualreason = tag->getString("reason", "Fix your client!");
+
+		// No need to send VERSION here, it's already taken care of
+		if (!strcmp(ctcpstring.c_str(), "VERSION"))
+		{
+			throw ModuleException(this, "Cannot use \"VERSION\" in secondary CTCP (\"ctcpstring\")");
+			ctcpstring.clear();
+		}
+
+		// Rebuild the badversions vector
+		badversions.clear();
+		for (const auto& [_, itag] : ServerInstance->Config->ConfTags("badversion"))
+		{
+			const std::string mask = itag->getString("mask");
+
+			if (mask.empty())
+			{
+				throw ModuleException(this, "Missing \"mask\" in <badversion> tag at " + itag->source.str());
+				continue;
+			}
+
+			BadVersion bv;
+			bv.mask = mask;
+			bv.ban = itag->getBool("ban");
+			bv.duration = itag->getDuration("duration", 60*60*24*7);
+			bv.reason = itag->getString("reason", "Upgrade your client!");
+			badversions.push_back(bv);
+		}
+
+		// Rebuild the banmissings vector
+		banmissings.clear();
+		for (const auto& [_, itag] : ServerInstance->Config->ConfTags("banmissing"))
+		{
+			BanMissing bm;
+			bm.cap = itag->getBool("cap");
+			bm.ctcp = itag->getBool("ctcp");
+			bm.version = itag->getBool("version");
+			bm.duration = itag->getDuration("duration", 60*60*24);
+			bm.reason = itag->getString("reason", "Fix your client!");
+			banmissings.push_back(bm);
+		}
+	}
+
+	ModResult OnCheckReady(LocalUser* user) override
+	{
+		// Allow user to be held here for up to 'timeout' seconds
+		if (user->signon + timeout <= ServerInstance->Time())
+			return MOD_RES_PASSTHRU;
+
+		UserData* ud = userdata.Get(user);
+		if (!ud)
+			return MOD_RES_PASSTHRU;
+
+		// Hold while waiting for replies
+		if ((!disableversion && ud->firstversionreply.empty()) ||
+		   (dualversion && ud->secondversionreply.empty()) ||
+		   (!ctcpstring.empty() && !ud->ctcpreply))
+			return MOD_RES_DENY;
+
+		return MOD_RES_PASSTHRU;
+	}
+
+	ModResult OnPreCommand(std::string& command, CommandBase::Params& parameters, LocalUser* user, bool validated) override
+	{
+		// Make sure we care about this user first
+		UserData* ud = userdata.Get(user);
+		if (!ud)
+			return MOD_RES_PASSTHRU;
+
+		// Mark self quitters to avoid messaging or Z-Lining them
+		if (command == "QUIT")
+		{
+			ud->selfquit = true;
+			return MOD_RES_PASSTHRU;
+		}
+
+		// Now we check for three important things:
+		// 1) The command is a NOTICE (not yet validated)
+		// 2) The NOTICE is to us
+		// 3) The NOTICE contains at least one parameter after the target
+		if (command != "NOTICE" || validated || parameters.size() < 2 || parameters[0] != ServerInstance->Config->ServerName)
+			return MOD_RES_PASSTHRU;
+
+		const std::string& param = parameters[1];
+		// Check for length and the wrapper char
+		if (param.length() < 2 || param[0] != wrapper)
+			return MOD_RES_PASSTHRU;
+
+		// VERSION reply that we are expecting
+		if (!disableversion && ud->expectversion && !param.compare(1, ctcpversion.length(), ctcpversion))
+		{
+			const std::string& rplversion = (param.length() > len_part ? param.substr(len_part, param.length() - len_all) : "");
+			const std::string& firstversionreply = ud->firstversionreply;
+			const std::string& secondversionreply = ud->secondversionreply;
+
+			ud->expectversion = false;
+
+			// Ignore empty replies
+			if (rplversion.empty())
+				return MOD_RES_DENY;
+
+			// Check for a match to a configured <badversion>
+			for (std::vector<BadVersion>::const_iterator it = badversions.begin(); it != badversions.end(); ++it)
+			{
+				const BadVersion& bv = *it;
+				if (!InspIRCd::Match(rplversion, bv.mask))
+					continue;
+
+				if (bv.ban)
+					SetZLine(user, bv.duration, bv.reason, "badversion");
+
+				ServerInstance->SNO.WriteToSnoMask('u', "Blocked user %s (%s) [%s] on port %d, version reply \"%s\" matched badversion mask \"%s\"",
+					user->GetRealMask().c_str(), user->GetAddress().c_str(), user->GetRealName().c_str(), user->server_sa.port(), rplversion.c_str(), bv.mask.c_str());
+				ud->zapped = true;
+				ServerInstance->Users.QuitUser(user, bv.reason);
+
+				return MOD_RES_DENY;
+			}
+
+			// First reply
+			if (firstversionreply.empty())
+			{
+				ud->firstversionreply = rplversion;
+				if (dualversion)
+				{
+					ud->expectversion = true;
+					const std::string msg = wrapper + ctcpversion + wrapper;
+					ClientProtocol::Messages::Privmsg ctcp(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->Config->ServerName, user, msg);
+					user->Send(ServerInstance->GetRFCEvents().privmsg, ctcp);
+				}
+			}
+			// Second reply
+			else if (secondversionreply.empty())
+				ud->secondversionreply = rplversion;
+
+			if (dualversion && (!firstversionreply.empty() && !secondversionreply.empty() && firstversionreply != secondversionreply))
+			{
+				if (dualban)
+					SetZLine(user, dualduration, dualreason, "dual");
+
+				ServerInstance->SNO.WriteToSnoMask('u', "Blocked user %s (%s) [%s] from connecting on port %d for mismatched version replies",
+					user->GetRealMask().c_str(), user->GetAddress().c_str(), user->GetRealName().c_str(), user->server_sa.port());
+
+				if (dualshow)
+					ServerInstance->SNO.WriteToSnoMask('u', "Version replies \"%s\" and \"%s\"", firstversionreply.c_str(), secondversionreply.c_str());
+
+				ud->zapped = true;
+				ServerInstance->Users.QuitUser(user, dualreason);
+			}
+
+			return MOD_RES_DENY;
+		}
+		// Configurable CTCP string reply that we are expecting
+		else if (!ctcpstring.empty() && ud->expectctcp && !param.compare(1, ctcpstring.length(), ctcpstring))
+		{
+			ud->expectctcp = false;
+			ud->ctcpreply = true;
+
+			return MOD_RES_DENY;
+		}
+
+		return MOD_RES_PASSTHRU;
+	}
+
+	void OnPostCommand(Command* command, const CommandBase::Params& parameters, LocalUser* user, CmdResult result, bool loop) override
+	{
+		if (command->name != "CAP")
+			return;
+
+		UserData* ud = userdata.Get(user);
+
+		if (ud && !parameters.empty() && irc::equals(parameters[0], "LS"))
+			ud->sentcap = true;
+	}
+
+	ModResult OnPreChangeConnectClass(LocalUser* user, const std::shared_ptr<ConnectClass>& klass, std::optional<Numeric::Numeric>& errnum) override
+	{
+		auto cc = klass.get();
+
+		// Don't mess with the initial class setting
+		// This way we only act after the client has had time to send CAP or CTCP replies
+		if (user->connected != User::CONN_NICKUSER)
+			return MOD_RES_PASSTHRU;
+
+		UserData* ud = userdata.Get(user);
+		if (!ud)
+			return MOD_RES_PASSTHRU;
+
+		// Check class requirements against our UserData
+		if ((!cc->config->getBool("requirecap") || ud->sentcap) &&
+		   (disableversion || !cc->config->getBool("requireversion") || !ud->firstversionreply.empty()) &&
+		   (ctcpstring.empty() || !cc->config->getBool("requirectcp") || ud->ctcpreply))
+			return MOD_RES_PASSTHRU;
+
+		ud->ccblocked = true;
+		return MOD_RES_DENY;
+	}
+
+	void OnUserPostInit(LocalUser* user) override
+	{
+		// Initialize their UserData and send the CTCP request(s)
+		UserData* ud = new UserData;
+		userdata.Set(user, ud);
+
+		if (!disableversion)
+		{
+			ud->expectversion = true;
+			const std::string msg = wrapper + ctcpversion + wrapper;
+			ClientProtocol::Messages::Privmsg ctcp(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->Config->ServerName, user, msg);
+			user->Send(ServerInstance->GetRFCEvents().privmsg, ctcp);
+		}
+		if (!ctcpstring.empty())
+		{
+			ud->expectctcp = true;
+			const std::string msg = wrapper + ctcpstring + wrapper;
+			ClientProtocol::Messages::Privmsg ctcp(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->Config->ServerName, user, msg);
+			user->Send(ServerInstance->GetRFCEvents().privmsg, ctcp);
+		}
+	}
+
+	void OnUserConnect(LocalUser* user) override
+	{
+		// If they made it here, they passed; ditch their UserData
+		if (userdata.Get(user))
+			userdata.Unset(user);
+	}
+
+	void OnUserDisconnect(LocalUser* user) override
+	{
+		// Skip proper users
+		if (user->IsFullyConnected())
+			return;
+
+		// Skip users with a socket level error
+		// This ignores things like port scans, ZNC cert errors, etc.
+		if (!user->eh.GetError().empty())
+			return;
+
+		// Skip users we don't know about or that self quit
+		UserData* ud = userdata.Get(user);
+		if (!ud || ud->selfquit)
+			return;
+
+		// We already disconnected (and possibly banned) these users
+		if (ud->zapped)
+			return;
+
+		// We didn't block any connect classes for this user.
+		if (!ud->ccblocked)
+		{
+			ServerInstance->Logs.Debug(MODNAME, "Unregistered user exiting for unknown reasons: %s (%s) [%s]",
+				user->GetRealMask().c_str(), user->GetAddress().c_str(), user->GetRealName().c_str());
+			return;
+		}
+
+		// Send them a message if configured
+		if (!blockmessage.empty())
+			user->WriteNotice(blockmessage);
+
+		bool noCap = !ud->sentcap;
+		bool noRpl = (!ctcpstring.empty() && !ud->ctcpreply);
+		bool noVer = (!disableversion && ud->firstversionreply.empty());
+
+		// Check for a match to our BanMissing and then Z-Line
+		for (std::vector<BanMissing>::const_iterator it = banmissings.begin(); it != banmissings.end(); ++it)
+		{
+			const BanMissing& bm = *it;
+
+			// We need to match a <banmissing> entirely. So if we want to match
+			// to missing version and ctcpstring but not cap, we need to skip
+			// any users that are missing cap; and so forth.
+			if (((!bm.cap && noCap) || (bm.cap && !noCap)) ||
+			   ((!bm.ctcp && noRpl) || (bm.ctcp && !noRpl)) ||
+			   ((!bm.version && noVer) || (bm.version && !noVer)))
+				continue;
+
+			SetZLine(user, bm.duration, bm.reason, "banmissing");
+		}
+
+		// Send out a SNOTICE that we likely caused this user to not get through
+		std::string buffer = "Unregistered user exiting: " + user->GetRealMask();
+		buffer.append(" (" + std::string(user->GetAddress()) + ") [" + user->GetRealName() + "]");
+		buffer.append(" on port " + ConvToStr(user->server_sa.port()));
+		buffer.append(". Possibly due to missing: ");
+		if (noCap)
+			buffer.append("CAP, ");
+		if (noRpl)
+			buffer.append(ctcpstring + " REPLY, ");
+		if (noVer)
+			buffer.append("VERSION REPLY");
+
+		// Remove trailing ", " if there
+		if (buffer[buffer.length() - 1] == ' ')
+			buffer.erase(buffer.length() - 2, 2);
+
+		ServerInstance->SNO.WriteToSnoMask('u', buffer);
+	}
+};
+
+MODULE_INIT(ModuleConnRequire)

--- a/4/m_conn_require.cpp
+++ b/4/m_conn_require.cpp
@@ -20,7 +20,7 @@
 /// $ModAuthor: genius3000
 /// $ModAuthorMail: genius3000@g3k.solutions
 /// $ModConfig: <connrequire timeout="5" ctcpstring="TIME" blockmessage="Your client isn't up to spec!">
-/// $ModDepends: core 3
+/// $ModDepends: core 4
 /// $ModDesc: Allow or block connections based on multiple criteria
 
 /* More available config tags:

--- a/4/m_conn_require.cpp
+++ b/4/m_conn_require.cpp
@@ -1,6 +1,7 @@
 /*
  * InspIRCd -- Internet Relay Chat Daemon
  *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
  *   Copyright (C) 2018-2020 Matt Schatz <genius3000@g3k.solutions>
  *
  * This file is a module for InspIRCd.  InspIRCd is free software: you can

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -133,13 +133,14 @@ class ModuleFakeList : public Module
 				switch (onJoin) {
 					case NONE: // Do nothing.
 						break;
-					case KILL: // They did the unspeakable, kill them!
-						ServerInstance->Users.QuitUser(user, reason);
-						break;
 					case GLINE:
 					case KLINE:
 					case ZLINE: // They did the unspeakable, nuke them!
 						AddXLine(user);
+						ServerInstance->Users.QuitUser(user, reason); // Oh and kill too, just in case.
+						break;
+					case KILL: // They did the unspeakable, kill them!
+						ServerInstance->Users.QuitUser(user, reason);
 						break;
 				}
 			}
@@ -190,14 +191,19 @@ class ModuleFakeList : public Module
 				break;
 		}
 
-		std::string durationStr;
+		std::string durationStr, expireStr;
+
 		if (duration == 0)
 		{
 			durationStr = "permanent";
+			expireStr = "";
 		}
 		else
 		{
-			durationStr = Duration::ToString(duration);
+			durationStr = "timed";
+			expireStr = INSP_FORMAT(", expires in {} (on {})",
+				Duration::ToString(duration),
+				Time::ToString(ServerInstance->Time() + duration));
 		}
 
 		time_t addTime = ServerInstance->Time();
@@ -207,8 +213,8 @@ class ModuleFakeList : public Module
 
 		if (ServerInstance->XLines->AddLine(line, nullptr))
 		{
-			ServerInstance->SNO.WriteToSnoMask('x', "%s added a %s-line (%s) for %s due to: %s",
-				src.c_str(), lineType.c_str(), durationStr.c_str(), mask.c_str(), reason.c_str());
+			ServerInstance->SNO.WriteToSnoMask('x', "{} added a {} {}-line for {}{} due to: {}",
+				src, durationStr, lineType, durationStr, mask, expireStr, reason);
 		}
 		else
 		{

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -76,7 +76,7 @@ class ModuleFakeList : public Module
 			newallows.push_back(host);
 		}
 
-		ConfigTag* tag = ServerInstance->Config->ConfValue("fakelist").get();
+		const auto& tag = ServerInstance->Config->ConfValue("fakelist");
 
 		exemptregistered = tag->getBool("exemptregistered");
 		WaitTime = tag->getDuration("waittime", 60, 1);

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -214,7 +214,7 @@ class ModuleFakeList : public Module
 		if (ServerInstance->XLines->AddLine(line, nullptr))
 		{
 			ServerInstance->SNO.WriteToSnoMask('x', "{} added a {} {}-line for {}{} due to: {}",
-				src, durationStr, lineType, durationStr, mask, expireStr, reason);
+				src, durationStr, lineType, mask, expireStr, reason);
 		}
 		else
 		{

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -102,7 +102,7 @@ class ModuleFakeList : public Module
 		if (!validated)
 			return MOD_RES_PASSTHRU;
 
-		if ((command == "LIST") && (ServerInstance->Time() < (user->signon+WaitTime)) && (!user->IsOper()))
+		if ((command == "LIST") && (static_cast<unsigned long>(ServerInstance->Time()) < (user->signon+WaitTime)) && (!user->IsOper()))
 		{
 			/* Normally wouldnt be allowed here, are they exempt? */
 			for (std::vector<std::string>::iterator x = allowlist.begin(); x != allowlist.end(); x++)

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -1,0 +1,135 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2007 Robin Burchell <robin+git@viroteck.net>
+ *   Copyright (C) 2006-2007 Craig Edwards <craigedwards@brainbox.cc>
+ *   Copyright (C) 2018-2019 James Lu <james@overdrivenetworks.com>
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+#include "modules/account.h"
+
+/// $ModAuthor: James Lu
+/// $ModAuthorMail: james@overdrivenetworks.com
+/// $ModDepends: core 4
+/// $ModDesc: Turns /list into a honeypot for newly connected users
+/// $ModConfig: <fakelist waittime="30s" reason="User hit a spam trap" target="#spamtrap" minusers="20" maxusers="50" topic="SPAM TRAP: DO NOT JOIN, YOU WILL BE DISCONNECTED! (try again later for a real reply)" killonjoin="true">
+
+typedef std::vector<std::string> AllowList;
+
+class ModuleFakeList : public Module
+{
+	Account::API accountapi;
+	AllowList allowlist;
+	bool exemptregistered;
+	unsigned int WaitTime;
+
+	std::string targetChannel;
+	std::string topic;
+	std::string reason;
+	unsigned int minUsers;
+	unsigned int maxUsers;
+	bool killOnJoin;
+
+ public:
+	ModuleFakeList() :
+		Module(VF_NONE, "Turns /list into a honeypot for newly connected users"),
+		accountapi(this)
+	{
+	}
+
+	void ReadConfig(ConfigStatus& status) override
+	{
+		AllowList newallows;
+
+		for (const auto& [_, tag] : ServerInstance->Config->ConfTags("securehost"))
+		{
+			std::string host = tag->getString("exception");
+			if (host.empty())
+				throw ModuleException(this, "<securehost:exception> is a required field at " + tag->source.str());
+			newallows.push_back(host);
+		}
+
+		ConfigTag* tag = ServerInstance->Config->ConfValue("fakelist").get();
+
+		exemptregistered = tag->getBool("exemptregistered");
+		WaitTime = tag->getDuration("waittime", 60, 1);
+		allowlist.swap(newallows);
+
+		reason = tag->getString("reason", "User hit a spam trap", 1);
+		targetChannel = tag->getString("target", "#spamtrap");
+		topic = tag->getString("topic", "SPAM TRAP: DO NOT JOIN, YOU WILL BE DISCONNECTED! (try again later for a real reply)");
+		minUsers = tag->getNum("minusers", 20U, 1U);
+		maxUsers = tag->getNum("maxusers", 50U, minUsers);
+		killOnJoin = tag->getBool("killonjoin", true);
+	}
+
+
+	/*
+	 * OnPreCommand()
+	 *   Intercept the LIST command.
+	 */
+	ModResult OnPreCommand(std::string& command, CommandBase::Params& parameters, LocalUser* user, bool validated) override
+	{
+		/* If the command doesnt appear to be valid, we dont want to mess with it. */
+		if (!validated)
+			return MOD_RES_PASSTHRU;
+
+		if ((command == "LIST") && (ServerInstance->Time() < (user->signon+WaitTime)) && (!user->IsOper()))
+		{
+			/* Normally wouldnt be allowed here, are they exempt? */
+			for (std::vector<std::string>::iterator x = allowlist.begin(); x != allowlist.end(); x++)
+				if (InspIRCd::Match(user->GetRealMask(), *x, ascii_case_insensitive_map))
+					return MOD_RES_PASSTHRU;
+
+			if (exemptregistered && accountapi && accountapi->GetAccountName(user))
+				return MOD_RES_PASSTHRU;
+
+			// Yeah, just give them some fake channels to ponder.
+			unsigned long int userCount = ServerInstance->GenRandomInt(maxUsers-minUsers) + minUsers;
+
+			user->WriteNumeric(RPL_LISTSTART, "Channel", "Users Name");
+			user->WriteNumeric(RPL_LIST, targetChannel, userCount, topic);
+			user->WriteNumeric(RPL_LISTEND, "End of channel list.");
+
+			return MOD_RES_DENY;
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven, bool override) override
+	{
+		if (killOnJoin && irc::equals(cname, targetChannel))
+		{
+			if (!user->IsOper())
+			{
+				// They did the unspeakable, kill them!
+				ServerInstance->Users.QuitUser(user, reason);
+			}
+			else
+			{
+				// Berate opers who try to do the same. (this uses the same numeric as CBAN in 3.0)
+				user->WriteNumeric(926, cname, "Cannot join channel (Reserved spamtrap channel for fakelist)");
+			}
+			return MOD_RES_DENY;
+		}
+		return MOD_RES_PASSTHRU;
+	}
+};
+
+MODULE_INIT(ModuleFakeList)

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -169,52 +169,43 @@ class ModuleFakeList : public Module
 	}
 
 	void AddXLine(User* user) {
-		auto lineType = GetLineType();
+		std::string src = "m_fakelist@" + ServerInstance->Config->ServerName;
+		XLine* line = nullptr;
 
-		XLineFactory* factory = ServerInstance->XLines->GetFactory(lineType);
-		if (!factory)
-		{
-			return;
-		}
-
-		std::string mask;
 		switch (onJoin)
 		{
 			case GLINE:
+				line = new GLine(ServerInstance->Time(), duration, src, reason, user->GetRealUser(), user->GetRealHost());
+				break;
 			case KLINE:
-				mask = user->GetRealUserHost();
+				line = new KLine(ServerInstance->Time(), duration, src, reason, user->GetRealUser(), user->GetRealHost());
 				break;
 			case ZLINE:
-				mask = user->GetAddress();
+				line = new ZLine(ServerInstance->Time(), duration, src, reason, user->GetAddress());
 				break;
 			default: // should be unreachable
-				break;
+				return;
 		}
-
-		std::string durationStr, expireStr;
-
-		if (duration == 0)
-		{
-			durationStr = "permanent";
-			expireStr = "";
-		}
-		else
-		{
-			durationStr = "timed";
-			expireStr = INSP_FORMAT(", expires in {} (on {})",
-				Duration::ToString(duration),
-				Time::ToString(ServerInstance->Time() + duration));
-		}
-
-		time_t addTime = ServerInstance->Time();
-		std::string src = ServerInstance->Config->ServerName;
-
-		XLine* line = factory->Generate(addTime, duration, src, reason, mask);
 
 		if (ServerInstance->XLines->AddLine(line, nullptr))
 		{
+			std::string durationStr, expireStr;
+
+			if (duration == 0)
+			{
+				durationStr = "permanent";
+				expireStr = "";
+			}
+			else
+			{
+				durationStr = "timed";
+				expireStr = INSP_FORMAT(", expires in {} (on {})",
+					Duration::ToString(duration),
+					Time::ToString(ServerInstance->Time() + duration));
+			}
+
 			ServerInstance->SNO.WriteToSnoMask('x', "{} added a {} {}-line for {}{} due to: {}",
-				src, durationStr, lineType, mask, expireStr, reason);
+				src, durationStr, line->type, line->Displayable(), expireStr, reason);
 		}
 		else
 		{

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -47,7 +47,7 @@ class ModuleFakeList : public Module
 	Account::API accountapi;
 	AllowList allowlist;
 	bool exemptregistered;
-	unsigned int WaitTime;
+	unsigned long WaitTime;
 
 	std::string targetChannel;
 	std::string topic;

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -22,15 +22,25 @@
 
 
 #include "inspircd.h"
+#include "timeutils.h"
+#include "xline.h"
 #include "modules/account.h"
 
 /// $ModAuthor: James Lu
 /// $ModAuthorMail: james@overdrivenetworks.com
 /// $ModDepends: core 4
 /// $ModDesc: Turns /list into a honeypot for newly connected users
-/// $ModConfig: <fakelist waittime="30s" reason="User hit a spam trap" target="#spamtrap" minusers="20" maxusers="50" topic="SPAM TRAP: DO NOT JOIN, YOU WILL BE DISCONNECTED! (try again later for a real reply)" killonjoin="true">
+/// $ModConfig: <fakelist waittime="30s" reason="User hit a spam trap" target="#spamtrap" minusers="20" maxusers="50" topic="SPAM TRAP: DO NOT JOIN, YOU WILL BE DISCONNECTED! (try again later for a real reply)" onjoin="none/kill/gline/kline/zline" duration="1d">
 
 typedef std::vector<std::string> AllowList;
+
+enum OnJoinActionType {
+	NONE,
+	KILL,
+	GLINE,
+	KLINE,
+	ZLINE,
+};
 
 class ModuleFakeList : public Module
 {
@@ -44,7 +54,8 @@ class ModuleFakeList : public Module
 	std::string reason;
 	unsigned int minUsers;
 	unsigned int maxUsers;
-	bool killOnJoin;
+	OnJoinActionType onJoin;
+	time_t duration;
 
  public:
 	ModuleFakeList() :
@@ -76,7 +87,8 @@ class ModuleFakeList : public Module
 		topic = tag->getString("topic", "SPAM TRAP: DO NOT JOIN, YOU WILL BE DISCONNECTED! (try again later for a real reply)");
 		minUsers = tag->getNum("minusers", 20U, 1U);
 		maxUsers = tag->getNum("maxusers", 50U, minUsers);
-		killOnJoin = tag->getBool("killonjoin", true);
+		onJoin = tag->getEnum("onjoin", NONE, {{"none", NONE},{"kill",KILL},{"gline",GLINE},{"kline",KLINE},{"zline",ZLINE}});
+		duration = tag->getDuration("duration", 86400); // 1 day by default
 	}
 
 
@@ -114,12 +126,22 @@ class ModuleFakeList : public Module
 
 	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven, bool override) override
 	{
-		if (killOnJoin && irc::equals(cname, targetChannel))
+		if (irc::equals(cname, targetChannel))
 		{
 			if (!user->IsOper())
 			{
-				// They did the unspeakable, kill them!
-				ServerInstance->Users.QuitUser(user, reason);
+				switch (onJoin) {
+					case NONE: // Do nothing.
+						break;
+					case KILL: // They did the unspeakable, kill them!
+						ServerInstance->Users.QuitUser(user, reason);
+						break;
+					case GLINE:
+					case KLINE:
+					case ZLINE: // They did the unspeakable, nuke them!
+						AddXLine(user);
+						break;
+				}
 			}
 			else
 			{
@@ -129,6 +151,69 @@ class ModuleFakeList : public Module
 			return MOD_RES_DENY;
 		}
 		return MOD_RES_PASSTHRU;
+	}
+
+	std::string GetLineType()
+	{
+		switch (onJoin) {
+			case GLINE:
+				return "G";
+			case KLINE:
+				return "K";
+			case ZLINE:
+				return "Z";
+			default:
+				return "-";
+		}
+	}
+
+	void AddXLine(User* user) {
+		auto lineType = GetLineType();
+
+		XLineFactory* factory = ServerInstance->XLines->GetFactory(lineType);
+		if (!factory)
+		{
+			return;
+		}
+
+		std::string mask;
+		switch (onJoin)
+		{
+			case GLINE:
+			case KLINE:
+				mask = user->GetRealUserHost();
+				break;
+			case ZLINE:
+				mask = user->GetAddress();
+				break;
+			default: // should be unreachable
+				break;
+		}
+
+		std::string durationStr;
+		if (duration == 0)
+		{
+			durationStr = "permanent";
+		}
+		else
+		{
+			durationStr = Duration::ToString(duration);
+		}
+
+		time_t addTime = ServerInstance->Time();
+		std::string src = ServerInstance->Config->ServerName;
+
+		XLine* line = factory->Generate(addTime, duration, src, reason, mask);
+
+		if (ServerInstance->XLines->AddLine(line, nullptr))
+		{
+			ServerInstance->SNO.WriteToSnoMask('x', "%s added a %s-line (%s) for %s due to: %s",
+				src.c_str(), lineType.c_str(), durationStr.c_str(), mask.c_str(), reason.c_str());
+		}
+		else
+		{
+			delete line;
+		}
 	}
 };
 

--- a/4/m_fakelist.cpp
+++ b/4/m_fakelist.cpp
@@ -26,8 +26,7 @@
 #include "xline.h"
 #include "modules/account.h"
 
-/// $ModAuthor: James Lu
-/// $ModAuthorMail: james@overdrivenetworks.com
+/// $ModAuthor: James Lu <james@overdrivenetworks.com>
 /// $ModDepends: core 4
 /// $ModDesc: Turns /list into a honeypot for newly connected users
 /// $ModConfig: <fakelist waittime="30s" reason="User hit a spam trap" target="#spamtrap" minusers="20" maxusers="50" topic="SPAM TRAP: DO NOT JOIN, YOU WILL BE DISCONNECTED! (try again later for a real reply)" onjoin="none/kill/gline/kline/zline" duration="1d">

--- a/4/m_jumpserver.cpp
+++ b/4/m_jumpserver.cpp
@@ -19,8 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// $ModAuthor: InspIRCd Developers
-/// $ModAuthorMail: noreply@inspircd.org
+/// $ModAuthor: TheUnstoppable <theunstoppable1000@gmail.com>
 /// $ModDepends: core 4
 /// $ModDesc: Provides support for the RPL_REDIR numeric and the /JUMPSERVER command.
 

--- a/4/m_jumpserver.cpp
+++ b/4/m_jumpserver.cpp
@@ -1,0 +1,202 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *   Copyright (C) 2007-2008 Craig Edwards <craigedwards@brainbox.cc>
+ *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2007 Robin Burchell <robin+git@viroteck.net>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: InspIRCd Developers
+/// $ModAuthorMail: noreply@inspircd.org
+/// $ModDepends: core 4
+/// $ModDesc: Provides support for the RPL_REDIR numeric and the /JUMPSERVER command.
+
+
+#include "inspircd.h"
+#include "modules/ssl.h"
+
+enum
+{
+	// From ircd-ratbox.
+	RPL_REDIR = 10
+};
+
+/** Handle /JUMPSERVER
+ */
+class CommandJumpserver : public Command
+{
+ public:
+	bool redirect_new_users;
+	std::string redirect_to;
+	std::string reason;
+	int port;
+	int sslport;
+	UserCertificateAPI sslapi;
+
+	CommandJumpserver(Module* Creator)
+		: Command(Creator, "JUMPSERVER", 0, 4)
+		, sslapi(Creator)
+	{
+		allow_empty_last_param = false;
+		access_needed = CmdAccess::OPERATOR;
+		syntax = { "<server> <port>[:<sslport>] <+/-an> <reason>" };
+		port = 0;
+		sslport = 0;
+		redirect_new_users = false;
+	}
+
+	CmdResult Handle(User* user, const Params& parameters) override
+	{
+		int n_done = 0;
+		bool redirect_all_immediately = false;
+		bool direction = true;
+		std::string n_done_s;
+
+		/* No parameters: jumpserver disabled */
+		if (parameters.empty())
+		{
+			if (port)
+				user->WriteNotice("*** Disabled jumpserver (previously set to '" + redirect_to + ":" + ConvToStr(port) + "')");
+			else
+				user->WriteNotice("*** Jumpserver was not enabled.");
+
+			port = 0;
+			sslport = 0;
+			redirect_new_users = false;
+			redirect_to.clear();
+			return CmdResult::SUCCESS;
+		}
+
+		port = 0;
+		reason = (parameters.size() < 4) ? "Please use this server/port instead" : parameters[3];
+		redirect_new_users = true;
+		redirect_to.clear();
+
+		if (parameters.size() >= 3)
+		{
+			for (std::string::const_iterator n = parameters[2].begin(); n != parameters[2].end(); ++n)
+			{
+				switch (*n)
+				{
+					case '+':
+						direction = true;
+					break;
+					case '-':
+						direction = false;
+					break;
+					case 'a':
+						redirect_all_immediately = direction;
+					break;
+					case 'n':
+						redirect_new_users = direction;
+					break;
+					default:
+						user->WriteNotice("*** Invalid JUMPSERVER flag: " + ConvToStr(*n));
+						return CmdResult::FAILURE;
+					break;
+				}
+			}
+
+			size_t delimpos = parameters[1].find(':');
+			port = ConvToNum<int>(parameters[1].substr(0, delimpos ? delimpos : std::string::npos));
+			sslport = (delimpos == std::string::npos ? 0 : ConvToNum<int>(parameters[1].substr(delimpos + 1)));
+
+			if (parameters[1].find_first_not_of("0123456789:") != std::string::npos
+				|| parameters[1].rfind(':') != delimpos
+				|| port > 65535 || sslport > 65535)
+			{
+				user->WriteNotice("*** Invalid port number");
+				return CmdResult::FAILURE;
+			}
+
+			if (redirect_all_immediately)
+			{
+				/* Redirect everyone but the oper sending the command */
+				const UserManager::LocalList& list = ServerInstance->Users.GetLocalUsers();
+				for (UserManager::LocalList::const_iterator i = list.begin(); i != list.end(); )
+				{
+					// Quitting the user removes it from the list
+					LocalUser* t = *i;
+					++i;
+					if (!t->IsOper())
+					{
+						t->WriteNumeric(RPL_REDIR, parameters[0], GetPort(t), "Please use this Server/Port instead");
+						ServerInstance->Users.QuitUser(t, reason);
+						n_done++;
+					}
+				}
+				if (n_done)
+				{
+					n_done_s = ConvToStr(n_done);
+				}
+			}
+
+			if (redirect_new_users)
+				redirect_to = parameters[0];
+
+			user->WriteNotice("*** Set jumpserver to server '" + parameters[0] + "' port '" + (port ? ConvToStr(port) : "Auto") + ", SSL " + (sslport ? ConvToStr(sslport) : "Auto") + "', flags '+" +
+				(redirect_all_immediately ? "a" : "") + (redirect_new_users ? "n'" : "'") +
+				(n_done ? " (" + n_done_s + "user(s) redirected): " : ": ") + reason);
+		}
+
+		return CmdResult::SUCCESS;
+	}
+
+	int GetPort(LocalUser* user)
+	{
+		int p = (sslapi && sslapi->GetCertificate(user) ? sslport : port);
+		if (p == 0)
+			p = user->server_sa.port();
+		return p;
+	}
+};
+
+class ModuleJumpServer : public Module
+{
+	CommandJumpserver js;
+ public:
+	ModuleJumpServer() : Module(VF_NONE, "Provides support for the RPL_REDIR numeric and the /JUMPSERVER command."),
+		js(this)
+	{
+	}
+
+	void OnModuleRehash(User* user, const std::string& param) override
+	{
+		if (irc::equals(param, "jumpserver") && js.redirect_new_users)
+			js.redirect_new_users = false;
+	}
+
+	ModResult OnUserRegister(LocalUser* user) override
+	{
+		if (js.redirect_new_users)
+		{
+			int port = js.GetPort(user);
+			user->WriteNumeric(RPL_REDIR, js.redirect_to, port, "Please use this Server/Port instead");
+			ServerInstance->Users.QuitUser(user, js.reason);
+			return MOD_RES_DENY;
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void ReadConfig(ConfigStatus& status) override
+	{
+		// Emergency way to unlock
+		if (!status.srcuser)
+			js.redirect_new_users = false;
+	}
+};
+
+MODULE_INIT(ModuleJumpServer)

--- a/4/m_relaymsg.cpp
+++ b/4/m_relaymsg.cpp
@@ -1,0 +1,211 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *   Copyright (C) 2020 James Lu <james@overdrivenetworks.com>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: jlu5
+/// $ModAuthorMail: james@overdrivenetworks.com
+/// $ModDepends: core 4
+/// $ModDesc: Provides the RELAYMSG command & draft/relaymsg capability for stateless bridging
+/// $ModConfig: <relaymsg separators="/" ident="relay" host="relay.example.com">
+//  The "host" option defaults to the local server hostname if not set.
+
+#include "inspircd.h"
+#include "numerichelper.h"
+#include "clientprotocolmsg.h"
+#include "modules/cap.h"
+#include "modules/ircv3.h"
+
+enum
+{
+    ERR_BADRELAYNICK = 573  // from ERR_CANNOTSENDRP in Oragono
+};
+
+// Registers the draft/relaymsg
+class RelayMsgCap : public Cap::Capability
+{
+public:
+    std::string nick_separators;
+
+    const std::string* GetValue(LocalUser* user) const override
+    {
+        return &nick_separators;
+    }
+
+    RelayMsgCap(Module* mod)
+        : Cap::Capability(mod, "draft/relaymsg")
+    {
+    }
+};
+
+// Handler for the @relaymsg message tag sent with forwarded PRIVMSGs
+class RelayMsgCapTag : public ClientProtocol::MessageTagProvider {
+private:
+    RelayMsgCap& cap;
+
+public:
+    RelayMsgCapTag(Module* mod, RelayMsgCap& Cap)
+        : ClientProtocol::MessageTagProvider(mod)
+        , cap(Cap)
+    {
+    }
+
+    bool ShouldSendTag(LocalUser* user, const ClientProtocol::MessageTagData& tagdata) override
+    {
+        return cap.IsEnabled(user);
+    }
+};
+
+// Handler for the RELAYMSG command (users and servers)
+class CommandRelayMsg : public Command
+{
+private:
+    RelayMsgCap& cap;
+    RelayMsgCapTag& captag;
+
+public:
+    std::string fake_host;
+    std::string fake_ident;
+
+    CommandRelayMsg(Module* parent, RelayMsgCap& Cap, RelayMsgCapTag& Captag)
+        : Command(parent, "RELAYMSG", 3, 3)
+        , cap(Cap)
+        , captag(Captag)
+    {
+        access_needed = CmdAccess::OPERATOR;
+        syntax = {"<channel>", "<nick>", "<text>"};
+        allow_empty_last_param = false;
+    }
+
+    std::string GetFakeHostmask(const std::string& nick) {
+        return INSP_FORMAT("%s!%s@%s", nick.c_str(), fake_ident.c_str(), fake_host.c_str());
+    }
+
+    CmdResult Handle(User* user, const CommandBase::Params& parameters)
+    {
+        const std::string& channame = parameters[0];
+        const std::string& nick = parameters[1];
+        const std::string& text = parameters[2];
+
+        // Check that the source has the relaymsg capability.
+        if (IS_LOCAL(user) && !cap.IsEnabled(user)) {
+            user->WriteNumeric(ERR_NOPRIVILEGES, "You must support the draft/relaymsg capability to use this command.");
+            return CmdResult::FAILURE;
+        }
+
+        Channel* channel = ServerInstance->Channels.Find(channame);
+        // Make sure the channel exists and the sender is in the channel
+        if (!channel)
+        {
+            user->WriteNumeric(Numerics::NoSuchChannel(channame));
+            return CmdResult::FAILURE;
+        }
+        if (!channel->HasUser(user))
+        {
+            user->WriteNumeric(Numerics::CannotSendTo(channel, "You must be in the channel to use this command."));
+            return CmdResult::FAILURE;
+        }
+
+        // Check that target nick is not already in use
+        if (ServerInstance->Users.FindNick(nick))
+        {
+            user->WriteNumeric(ERR_BADRELAYNICK, nick, "RELAYMSG spoofed nick is already in use");
+            return CmdResult::FAILURE;
+        }
+
+        // Make sure the nick doesn't include any core IRC characters (e.g. *, !)
+        // This should still be more flexible than regular nick checking - in particular
+        // we want to allow "/" and "~" for relayers
+        if (nick.find_first_of("!+%@&#$:'\"?*,.") != std::string::npos)
+        {
+            user->WriteNumeric(ERR_BADRELAYNICK, nick, "Invalid characters in spoofed nick");
+            return CmdResult::FAILURE;
+        }
+
+        // If the sender was a lcoal user, check that the target includes a nick separator
+        if (IS_LOCAL(user))
+        {
+            if (nick.find_first_of(cap.nick_separators) == std::string::npos)
+            {
+                user->WriteNumeric(ERR_BADRELAYNICK, nick, INSP_FORMAT("Spoofed nickname must include one of the following separators: %s", cap.nick_separators.c_str()));
+                return CmdResult::FAILURE;
+            }
+        }
+
+        // Send the message to everyone in the channel
+        std::string fakeSource = GetFakeHostmask(nick);
+        ClientProtocol::Messages::Privmsg privmsg(fakeSource, channel, text);
+        // Tag the message as @draft/relaymsg=<nick> so the sender can recognize it
+        // Also copy over tags set on the original /relaymsg command
+        privmsg.AddTags(parameters.GetTags());
+        privmsg.AddTag("draft/relaymsg", &captag, user->nick);
+        channel->Write(ServerInstance->GetRFCEvents().privmsg, privmsg);
+
+        if (IS_LOCAL(user))
+        {
+            // Pass the message on to other servers
+            CommandBase::Params params;
+            // Preserve other message tags sent with the /relaymsg command
+            params.GetTags().insert(parameters.GetTags().begin(), parameters.GetTags().end());
+            params.push_back(channame);
+            params.push_back(nick);
+            params.push_back(":" + text);
+
+            ServerInstance->PI->BroadcastEncap("RELAYMSG", params, user);
+        }
+
+        return CmdResult::SUCCESS;
+    };
+};
+
+class ModuleRelayMsg : public Module
+{
+    RelayMsgCap cap;
+    RelayMsgCapTag captag;
+    CommandRelayMsg cmd;
+
+public:
+    ModuleRelayMsg() :
+        Module(VF_NONE, "Provides the RELAYMSG command for stateless bridging"),
+        cap(this),
+        captag(this, cap),
+        cmd(this, cap, captag)
+    {
+    }
+
+    void ReadConfig(ConfigStatus& status) override
+    {
+        ConfigTag* tag = ServerInstance->Config->ConfValue("relaymsg").get();
+        std::string fake_ident = tag->getString("ident", "relay");
+        std::string fake_host = tag->getString("host", ServerInstance->Config->ServerName);
+
+        // Check these before replacement so that invalid values loaded during /rehash don't get saved
+        if (!ServerInstance->IsUser(fake_ident))
+        {
+            throw ModuleException(this, "Invalid ident value for <relaymsg>");
+        }
+        if (!InspIRCd::IsHost(fake_host, true))
+        {
+            throw ModuleException(this, "Invalid host value for <relaymsg>");
+        }
+        cmd.fake_host = fake_host;
+        cmd.fake_ident = fake_ident;
+        cap.nick_separators = tag->getString("separators", "/", 1);
+    }
+};
+
+MODULE_INIT(ModuleRelayMsg)

--- a/4/m_relaymsg.cpp
+++ b/4/m_relaymsg.cpp
@@ -92,7 +92,7 @@ public:
     }
 
     std::string GetFakeHostmask(const std::string& nick) {
-        return INSP_FORMAT("%s!%s@%s", nick.c_str(), fake_ident.c_str(), fake_host.c_str());
+        return INSP_FORMAT("{}!{}@{}", nick, fake_ident, fake_host);
     }
 
     CmdResult Handle(User* user, const CommandBase::Params& parameters)
@@ -141,7 +141,7 @@ public:
         {
             if (nick.find_first_of(cap.nick_separators) == std::string::npos)
             {
-                user->WriteNumeric(ERR_BADRELAYNICK, nick, INSP_FORMAT("Spoofed nickname must include one of the following separators: %s", cap.nick_separators.c_str()));
+                user->WriteNumeric(ERR_BADRELAYNICK, nick, INSP_FORMAT("Spoofed nickname must include one of the following separators: {}", cap.nick_separators));
                 return CmdResult::FAILURE;
             }
         }

--- a/4/m_relaymsg.cpp
+++ b/4/m_relaymsg.cpp
@@ -189,7 +189,7 @@ public:
 
     void ReadConfig(ConfigStatus& status) override
     {
-        ConfigTag* tag = ServerInstance->Config->ConfValue("relaymsg").get();
+        const auto& tag = ServerInstance->Config->ConfValue("relaymsg");
         std::string fake_ident = tag->getString("ident", "relay");
         std::string fake_host = tag->getString("host", ServerInstance->Config->ServerName);
 

--- a/4/m_relaymsg.cpp
+++ b/4/m_relaymsg.cpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// $ModAuthor: jlu5
-/// $ModAuthorMail: james@overdrivenetworks.com
+/// $ModAuthor: jlu5 <james@overdrivenetworks.com>
 /// $ModDepends: core 4
 /// $ModDesc: Provides the RELAYMSG command & draft/relaymsg capability for stateless bridging
 /// $ModConfig: <relaymsg separators="/" ident="relay" host="relay.example.com">

--- a/4/m_slowmode.cpp
+++ b/4/m_slowmode.cpp
@@ -1,0 +1,194 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2026 TheUnstoppable <theunstoppable1000@gmail.com>
+ *   Copyright (C) 2018 linuxdaemon <linuxdaemon@snoonet.org>
+ *   Copyright (C) 2016 Foxlet <foxlet@furcode.co>
+ *   Copyright (C) 2015 Adam <Adam@anope.org>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+#include "extension.h"
+#include "numerichelper.h"
+#include "modules/exemption.h"
+
+/// $ModAuthor: Adam
+/// $ModAuthorMail: adam@anope.org
+/// $ModConfig: <slowmode modechar="W">
+/// $ModDesc: Provides channel mode +W (slow mode)
+/// $ModDepends: core 4
+
+/** Holds slowmode settings and state for mode +W
+ */
+class slowmodesettings
+{
+ public:
+	typedef std::map<User*, unsigned int> user_counter_t;
+
+	unsigned int lines;
+	unsigned int secs;
+
+	bool user;
+
+	union
+	{
+		unsigned int counter;
+		user_counter_t* user_counter;
+	};
+
+	time_t reset;
+
+	slowmodesettings(int l, int s, bool u = false) : lines(l), secs(s), user(u), user_counter(0)
+	{
+		this->clear();
+		reset = ServerInstance->Time() + secs;
+	}
+
+	bool addmessage(User *who)
+	{
+		if (ServerInstance->Time() > reset)
+		{
+			this->clear();
+			reset = ServerInstance->Time() + secs;
+		}
+
+		if (user)
+			if (IS_LOCAL(who))
+				return ++((*user_counter)[who]) >= lines;
+			else
+				return false;
+		else
+			return ++counter >= lines;
+	}
+
+	void clear()
+	{
+		if (user)
+			if (user_counter)
+				user_counter->clear();
+			else
+				user_counter = new user_counter_t;
+		else
+			counter = 0;
+	}
+};
+
+/** Handles channel mode +W
+ */
+class MsgFlood : public ParamMode<MsgFlood, SimpleExtItem<slowmodesettings>>
+{
+ public:
+	MsgFlood(Module* Creator)
+		: ParamMode<MsgFlood, SimpleExtItem<slowmodesettings>>(Creator, "slowmode", ServerInstance->Config->ConfValue("slowmode")->getString("modechar", "W", 1, 1)[0])
+	{
+#if defined INSPIRCD_VERSION_SINCE && INSPIRCD_VERSION_SINCE(3, 2)
+		syntax = "[cu]<lines>:<seconds>";
+#endif
+	}
+
+	bool OnSet(User* source, Channel* channel, std::string& parameter) override
+	{
+		std::string::size_type colon = parameter.find(':');
+		if (colon == std::string::npos || parameter.find('-') != std::string::npos)
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(channel, this, parameter));
+			return false;
+		}
+
+		bool user;
+		switch (parameter[0])
+		{
+			case 'u':
+				user = true;
+				parameter.erase(0, 1);
+				colon--;
+				break;
+			case 'c':
+				parameter.erase(0, 1);
+				colon--;
+				/*@fallthrough@*/
+			default:
+				user = false;
+				break;
+		}
+
+		/* Set up the slowmode parameters for this channel */
+		unsigned int nlines = ConvToNum<unsigned int>(parameter.substr(0, colon));
+		unsigned int nsecs = ConvToNum<unsigned int>(parameter.substr(colon + 1));
+
+		if ((nlines < 2) || nsecs < 1)
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(channel, this, parameter));
+			return false;
+		}
+
+		slowmodesettings* f = ext.Get(channel);
+		if (f && nlines == f->lines && nsecs == f->secs && user == f->user)
+			// mode params match
+			return false;
+
+		ext.Set(channel, new slowmodesettings(nlines, nsecs, user));
+		parameter = std::string(user ? "u" : "c") + ConvToStr(nlines) + ":" + ConvToStr(nsecs);
+		return true;
+	}
+
+	void SerializeParam(Channel* chan, const slowmodesettings* sms, std::string& out)
+	{
+		out.push_back(sms->user ? 'u' : 'c');
+		out.append(ConvToStr(sms->lines));
+		out.push_back(':');
+		out.append(ConvToStr(sms->secs));
+	}
+};
+
+class ModuleMsgFlood : public Module
+{
+	MsgFlood mf;
+	CheckExemption::EventProvider exemptionprov;
+
+ public:
+	ModuleMsgFlood() :
+		Module(VF_COMMON, "Provides channel mode \"+W [u|c]<lines>:<secs>\" for slowmode"),
+		mf(this),
+		exemptionprov(this)
+	{
+	}
+
+	ModResult OnUserPreMessage(User* user, MessageTarget& target, MessageDetails& details) override
+	{
+		if (target.type != MessageTarget::TYPE_CHANNEL || user->server->IsService())
+			return MOD_RES_PASSTHRU;
+
+		Channel* dest = target.Get<Channel>();
+		if (!dest->IsModeSet(mf))
+			return MOD_RES_PASSTHRU;
+
+		if (exemptionprov.Check(user, dest, "slowmode") == MOD_RES_ALLOW)
+			return MOD_RES_PASSTHRU;
+
+		slowmodesettings *f = mf.ext.Get(dest);
+		if (f == NULL || !f->addmessage(user))
+			return MOD_RES_PASSTHRU;
+
+		if (!IS_LOCAL(user))
+			return MOD_RES_PASSTHRU;
+
+		user->WriteNumeric(ERR_CANNOTSENDTOCHAN, dest->name, "Message throttled due to flood");
+		return MOD_RES_DENY;
+	}
+};
+
+MODULE_INIT(ModuleMsgFlood)

--- a/4/m_slowmode.cpp
+++ b/4/m_slowmode.cpp
@@ -25,8 +25,7 @@
 #include "numerichelper.h"
 #include "modules/exemption.h"
 
-/// $ModAuthor: Adam
-/// $ModAuthorMail: adam@anope.org
+/// $ModAuthor: Adam <adam@anope.org>
 /// $ModConfig: <slowmode modechar="W">
 /// $ModDesc: Provides channel mode +W (slow mode)
 /// $ModDepends: core 4


### PR DESCRIPTION
## Summary
This PR adds a new module and imports various modules from v3 to v4.

### Added modules
- `m_conn_matchgecos`: Allows a connect class to match by real name(s)/gecos.

### Modules ported from v3 to v4
Modules below are from v3, with necessary changes to make them work on v4. Additional behavioral changes, if made, are noted next to each module. Otherwise, there should be no behavioral changes.
- `m_antirandom`: Renamed occurrences of "ident" to "realuser" in accordance with v4 changes.
- `m_close`
- `m_jumpserver`
- `m_conn_matchident`
- `m_conn_require`
- `m_relaymsg`
- `m_slowmode`
- `m_fakelist`: Added support to G-Line/K-Line/Z-Line. Renamed "killonjoin=true/false" to "onjoin=none/kill/gline/kline/zline" and added "duration" parameter.

## Checks

I have ensured that:

- [x] The code I am submitting is my own work and/or I have permission from the author to share it.
- [x] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
